### PR TITLE
Improved handling of IO errors.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,10 +6,9 @@ pipeline {
         // Use the docker to assign the Python version.
         // Use the label to assign the node to run the test.
         // It is recommended by SQUARE team do not add the label to let the
-        // sytem decide.
+        // system decide.
         docker {
             image 'lsstts/aos:w_2020_15'
-            args '-u root'
         }
     }
 
@@ -77,12 +76,6 @@ pipeline {
 
     post {
         always {
-            // Change the ownership of workspace to Jenkins for the clean up
-            // This is a "work around" method
-            withEnv(["HOME=${env.WORKSPACE}"]) {
-                sh 'chown -R 1003:1003 ${HOME}/'
-            }
-
             // The path of xml needed by JUnit is relative to
             // the workspace.
             junit "${env.XML_REPORT}"

--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-1.4.2:
+
+-------------
+1.4.2
+-------------
+
+Improved handling of IO errors - catch more OS Errors instead of only file not exists.
+
 .. _lsst.ts.wep-1.4.1:
 
 -------------

--- a/python/lsst/ts/wep/ParamReader.py
+++ b/python/lsst/ts/wep/ParamReader.py
@@ -16,10 +16,10 @@ class ParamReader(object):
 
         if (filePath is None):
             self.filePath = ""
+            self._content = dict()
         else:
             self.filePath = filePath
-
-        self._content = self._readContent(self.filePath)
+            self._content = self._readContent(self.filePath)
 
     def _readContent(self, filePath):
         """Read the content of file.
@@ -38,7 +38,9 @@ class ParamReader(object):
         try:
             with open(filePath, "r") as yamlFile:
                 return yaml.safe_load(yamlFile)
-        except IOError:
+        except IOError as err:
+            warnings.warn(f"Cannot open {filePath}: {str(err)}.",
+                          category=UserWarning)
             return dict()
 
     def getFilePath(self):

--- a/python/lsst/ts/wep/ParamReader.py
+++ b/python/lsst/ts/wep/ParamReader.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import yaml
 import warnings
@@ -146,7 +147,7 @@ class ParamReader(object):
             Matrix content.
         """
 
-        if (self._content == dict()):
+        if self._content == dict():
             mat = np.array([])
         else:
             mat = np.array(self._content)
@@ -193,7 +194,7 @@ class ParamReader(object):
             default is None.)
         """
 
-        if (filePath is None):
+        if filePath is None:
             filePath = self.filePath
         else:
             self.filePath = filePath

--- a/python/lsst/ts/wep/ParamReader.py
+++ b/python/lsst/ts/wep/ParamReader.py
@@ -1,4 +1,3 @@
-import os
 import numpy as np
 import yaml
 import warnings
@@ -36,13 +35,11 @@ class ParamReader(object):
             Content of file.
         """
 
-        if (os.path.exists(filePath)):
+        try:
             with open(filePath, "r") as yamlFile:
-                content = yaml.safe_load(yamlFile)
-        else:
-            content = dict()
-
-        return content
+                return yaml.safe_load(yamlFile)
+        except IOError:
+            return dict()
 
     def getFilePath(self):
         """Get the parameter file path.

--- a/tests/test_paramReader.py
+++ b/tests/test_paramReader.py
@@ -171,6 +171,11 @@ class TestParamReader(unittest.TestCase):
         filePathAbs = ParamReader.getAbsPath(filePath, getModulePath())
         self.assertTrue(os.path.isabs(filePathAbs))
 
+    def testNonexistentFile(self):
+
+        paramReader = ParamReader(filePath="thisFileDoesntExists")
+        self.assertEqual(len(paramReader.getContent().keys()), 0)
+
 
 if __name__ == "__main__":
 

--- a/tests/test_paramReader.py
+++ b/tests/test_paramReader.py
@@ -44,7 +44,8 @@ class TestParamReader(unittest.TestCase):
 
         fileName = "test.yaml"
         filePath = os.path.join(self.configDir, fileName)
-        self.paramReader.setFilePath(filePath)
+        with self.assertWarns(UserWarning):
+            self.paramReader.setFilePath(filePath)
 
         self.assertEqual(self.paramReader.getFilePath(), filePath)
 
@@ -173,7 +174,8 @@ class TestParamReader(unittest.TestCase):
 
     def testNonexistentFile(self):
 
-        paramReader = ParamReader(filePath="thisFileDoesntExists")
+        with self.assertWarns(UserWarning):
+            paramReader = ParamReader(filePath="thisFileDoesntExists")
         self.assertEqual(len(paramReader.getContent().keys()), 0)
 
 


### PR DESCRIPTION
The original code doesn't handled un-readable files and other corner cases.
Catching IOError handles more problems.