### PR TITLE
DM-29496: Update ts_wep import of DetectorType

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-1.5.7:
+
+-------------
+1.5.7
+-------------
+
+* Update import of `DetectorType`.
+
 .. _lsst.ts.wep-1.5.6:
 
 -------------

--- a/python/lsst/ts/wep/bsc/CameraData.py
+++ b/python/lsst/ts/wep/bsc/CameraData.py
@@ -135,7 +135,7 @@ class CameraData(object):
 
         Parameters
         ----------
-        detectorType : lsst.afw.cameraGeom.detector.detector.DetectorType
+        detectorType : lsst.afw.cameraGeom.DetectorType
             Detector type.
         """
 

--- a/python/lsst/ts/wep/bsc/ComCam.py
+++ b/python/lsst/ts/wep/bsc/ComCam.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from lsst.obs.lsst import LsstCamMapper
-from lsst.afw.cameraGeom.detector.detector import DetectorType
+from lsst.afw.cameraGeom import DetectorType
 
 from lsst.ts.wep.bsc.CameraData import CameraData
 

--- a/python/lsst/ts/wep/bsc/LsstCam.py
+++ b/python/lsst/ts/wep/bsc/LsstCam.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from lsst.obs.lsst import LsstCamMapper
-from lsst.afw.cameraGeom.detector.detector import DetectorType
+from lsst.afw.cameraGeom import DetectorType
 
 from lsst.ts.wep.bsc.CameraData import CameraData
 

--- a/python/lsst/ts/wep/bsc/LsstFamCam.py
+++ b/python/lsst/ts/wep/bsc/LsstFamCam.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from lsst.obs.lsst import LsstCamMapper
-from lsst.afw.cameraGeom.detector.detector import DetectorType
+from lsst.afw.cameraGeom import DetectorType
 
 from lsst.ts.wep.bsc.CameraData import CameraData
 


### PR DESCRIPTION
A small change from `from lsst.afw.cameraGeom.detector.detector import DetectorType`  to `from lsst.afw.cameraGeom import DetectorType`, needed from `w_2021_13`.