### PR TITLE
[DM-29787] Get instrument from pipeline in DonutCatalogOnlineTask

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,7 @@ pipeline {
                 withEnv(["HOME=${env.WORKSPACE}"]) {
                     sh """
                         source ${env.LSST_STACK}/loadLSST.bash
+                        setup ctrl_mpexec -t ${env.STACK_VERSION}
                         cd phosim_utils/
                         setup -k -r . -t ${env.STACK_VERSION}
                         scons
@@ -74,6 +75,7 @@ pipeline {
                 withEnv(["HOME=${env.WORKSPACE}"]) {
                     sh """
                         source ${env.LSST_STACK}/loadLSST.bash
+                        setup ctrl_mpexec -t ${env.STACK_VERSION}
                         cd phosim_utils/
                         setup -k -r . -t ${env.STACK_VERSION}
                         cd ..
@@ -128,7 +130,7 @@ pipeline {
                 }
               }
             }
-            
+
             // Change the ownership of workspace to Jenkins for the clean up
             // This is to work around the condition that the user ID of jenkins
             // is 1003 on TSSW Jenkins instance. In this post stage, it is the

--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,15 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-1.6.1:
+
+-------------
+1.6.1
+-------------
+
+* Update GenerateDonutCatalogOnlineTask.py to get instrument directly from pipeline configuration.
+* Setup `ctrl_mpexec` package in Jenkinsfile so tests can run `pipetask` command.
+
 .. _lsst.ts.wep-1.6.0:
 
 -------------

--- a/tests/task/test_generateDonutCatalogOnlineTask.py
+++ b/tests/task/test_generateDonutCatalogOnlineTask.py
@@ -45,6 +45,18 @@ class TestGenerateDonutCatalogOnlineTask(unittest.TestCase):
         self.butler = dafButler.Butler(self.repoDir)
         self.registry = self.butler.registry
 
+    def _writePipetaskCmd(self, runName, taskName):
+
+        pipetaskCmd = "pipetask run "
+        pipetaskCmd += f"-b {self.repoDir} "  # Specify repo
+        pipetaskCmd += "-i refcats "  # Specify collections with data to use
+        # Specify task
+        pipetaskCmd += f"-t lsst.ts.wep.task.{taskName} "
+        pipetaskCmd += "--instrument lsst.obs.lsst.LsstCam "
+        pipetaskCmd += f"--register-dataset-types --output-run {runName}"
+
+        return pipetaskCmd
+
     def validateConfigs(self):
 
         self.config.boresightRa = 0.03
@@ -75,15 +87,8 @@ class TestGenerateDonutCatalogOnlineTask(unittest.TestCase):
 
         # Run pipeline command
         runName = "run1"
-        pipetaskCmd = "pipetask run "
-        pipetaskCmd += f"-b {self.repoDir} "  # Specify repo
-        pipetaskCmd += "-i refcats "  # Specify collections with data to use
-        # Specify task
         taskName = "GenerateDonutCatalogOnlineTask.GenerateDonutCatalogOnlineTask"
-        pipetaskCmd += f"-t lsst.ts.wep.task.{taskName} "
-        pipetaskCmd += "--instrument lsst.obs.lsst.LsstCam "
-        pipetaskCmd += f"--register-dataset-types --output-run {runName}"
-
+        pipetaskCmd = self._writePipetaskCmd(runName, taskName)
         runProgram(pipetaskCmd)
 
         # Test instrument matches

--- a/tests/task/test_generateDonutCatalogOnlineTask.py
+++ b/tests/task/test_generateDonutCatalogOnlineTask.py
@@ -29,6 +29,7 @@ from lsst.ts.wep.task.GenerateDonutCatalogOnlineTask import (
     GenerateDonutCatalogOnlineTask,
     GenerateDonutCatalogOnlineTaskConfig,
 )
+from lsst.ts.wep.Utility import runProgram
 
 
 class TestGenerateDonutCatalogOnlineTask(unittest.TestCase):
@@ -50,14 +51,12 @@ class TestGenerateDonutCatalogOnlineTask(unittest.TestCase):
         self.config.boresightDec = -0.02
         self.config.boresightRotAng = 90.0
         self.config.filterName = "r"
-        self.cameraName = "lsstFamCam"
         self.task = GenerateDonutCatalogOnlineTask(config=self.config)
 
         self.assertEqual(self.task.boresightRa, 0.03)
         self.assertEqual(self.task.boresightDec, -0.02)
         self.assertEqual(self.task.boresightRotAng, 90.0)
         self.assertEqual(self.task.filterName, "r")
-        self.assertEqual(self.task.cameraName, "lsstFamCam")
 
     def testFilterResults(self):
 
@@ -67,6 +66,65 @@ class TestGenerateDonutCatalogOnlineTask(unittest.TestCase):
         testDataFrame = refCat.asAstropy().to_pandas()
         filteredDataFrame = self.task.filterResults(testDataFrame)
         np.testing.assert_array_equal(filteredDataFrame, testDataFrame)
+
+    def testPipeline(self):
+        """
+        Test that the task runs in a pipeline. Also functions as a test of
+        runQuantum function.
+        """
+
+        # Run pipeline command
+        runName = "run1"
+        pipetaskCmd = "pipetask run "
+        pipetaskCmd += f"-b {self.repoDir} "  # Specify repo
+        pipetaskCmd += "-i refcats "  # Specify collections with data to use
+        # Specify task
+        taskName = "GenerateDonutCatalogOnlineTask.GenerateDonutCatalogOnlineTask"
+        pipetaskCmd += f"-t lsst.ts.wep.task.{taskName} "
+        pipetaskCmd += "--instrument lsst.obs.lsst.LsstCam "
+        pipetaskCmd += f"--register-dataset-types --output-run {runName}"
+
+        runProgram(pipetaskCmd)
+
+        # Test instrument matches
+        pipelineButler = dafButler.Butler(self.repoDir)
+        outputDf = pipelineButler.get(
+            "donutCatalog", dataId={"instrument": "LSSTCam"}, collections=[f"{runName}"]
+        )
+        self.assertEqual(len(outputDf), 8)
+        self.assertEqual(len(outputDf.query('detector == "R22_S11"')), 4)
+        self.assertEqual(len(outputDf.query('detector == "R22_S10"')), 4)
+        self.assertCountEqual(
+            [
+                3806.7636478057957,
+                2806.982895217227,
+                607.3861483168994,
+                707.3972344551466,
+                614.607342274194,
+                714.6336433247832,
+                3815.2649173460436,
+                2815.0561553920156,
+            ],
+            outputDf["centroid_x"],
+        )
+        self.assertCountEqual(
+            [
+                3196.070534224157,
+                2195.666002294077,
+                394.8907003737886,
+                394.9087004171349,
+                396.2407036464963,
+                396.22270360324296,
+                3196.1965343932648,
+                2196.188002312585,
+            ],
+            outputDf["centroid_y"],
+        )
+
+        # Clean up
+        cleanUpCmd = "butler prune-collection "
+        cleanUpCmd += f"{self.repoDir} {runName} --purge --unstore"
+        runProgram(cleanUpCmd)
 
     def testDonutCatalogGeneration(self):
         """
@@ -80,7 +138,7 @@ class TestGenerateDonutCatalogOnlineTask(unittest.TestCase):
         ).expanded()
         for ref in datasetGenerator:
             deferredList.append(self.butler.getDeferred(ref, collections=["refcats"]))
-        taskOutput = self.task.run(deferredList)
+        taskOutput = self.task.run("LSSTCam", deferredList)
         outputDf = taskOutput.donutCatalog
 
         # Compare ra, dec info to original input catalog


### PR DESCRIPTION
In the new `GenerateDonutCatalogOnlineTask` in ts_wep the camera to set up the WCS is a configuration parameter. But I recently learned how to make it so that it will come from the pipeline settings. This is a better way to do things so it removes the possibility of having the camera in the pipeline be different from the camera set up to create the donutCatalog with X,Y pixel locations.