### PR TITLE
DM-30094: Fix ts_wep flake8 error

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-1.6.7:
+
+-------------
+1.6.7
+-------------
+
+* Fix flake error and update Jenkinsfile
+
 .. _lsst.ts.wep-1.6.6:
 
 -------------

--- a/python/lsst/ts/wep/task/DonutStamps.py
+++ b/python/lsst/ts/wep/task/DonutStamps.py
@@ -108,7 +108,8 @@ class DonutStamps(StampsBase):
         stampList.append(newStamp)
 
     def extend(self, newStampList):
-        """Extend DonutStamps instance by appending elements from another instance.
+        """Extend DonutStamps instance by appending elements
+        from another instance.
 
         Parameters
         ----------

--- a/python/lsst/ts/wep/task/EstimateZernikesFamTask.py
+++ b/python/lsst/ts/wep/task/EstimateZernikesFamTask.py
@@ -109,15 +109,19 @@ class EstimateZernikesFamTask(pipeBase.PipelineTask):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        # Set size (in pixels) of donut template image used for final centroiding by
-        # convolution of initial cutout with template
+        # Set size (in pixels) of donut template image used for
+        # final centroiding by convolution of initial cutout with template
         self.donutTemplateSize = self.config.donutTemplateSize
-        # Set final size (in pixels) of postage stamp images returned as DonutStamp objects
+        # Set final size (in pixels) of postage stamp images returned as
+        # DonutStamp objects
         self.donutStampSize = self.config.donutStampSize
-        # Add this many pixels onto each side of initial cutout stamp beyond the size
-        # specified in self.donutStampSize. This makes sure that after recentroiding
-        # the donut from the catalog position by convolving a template on the initial
-        # cutout stamp we will still have a postage stamp of size self.donutStampSize.
+        # Add this many pixels onto each side of initial
+        # cutout stamp beyond the size specified
+        # in self.donutStampSize. This makes sure that
+        # after recentroiding the donut from the catalog
+        # position by convolving a template on the initial
+        # cutout stamp we will still have a postage stamp
+        # of size self.donutStampSize.
         self.initialCutoutPadding = self.config.initialCutoutPadding
 
     def assignExtraIntraIdx(self, focusZVal0, focusZVal1):


### PR DESCRIPTION
Fixed flake8 error (too long line) in `DonutStamps.py` and `EstimateZernikesFamTask.py`, updated version history (add tag to `master`  after merge). 