### PR TITLE
Tickets/dm 30292

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,15 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-1.7.2:
+
+-------------
+1.7.2
+-------------
+
+* Fix ``append`` and ``extend`` methods in ``DonutStamps.py``.
+* Update tests in ``test_donutStamps.py`` to properly check ``append`` and ``extend`` methods.
+
 .. _lsst.ts.wep-1.7.1:
 
 -------------
@@ -41,8 +50,7 @@ Version History
 
 .. _lsst.ts.wep-1.6.7:
 
--------------
-1.6.7
+---------
 -------------
 
 * Fix flake error and update Jenkinsfile

--- a/python/lsst/ts/wep/task/DonutStamps.py
+++ b/python/lsst/ts/wep/task/DonutStamps.py
@@ -103,9 +103,8 @@ class DonutStamps(StampsBase):
         """
         if not isinstance(newStamp, DonutStamp):
             raise ValueError("Objects added must be a DonutStamp object.")
-        # Utilize functionality from upstream (StampsBase) code.
-        stampList = self[:]
-        stampList.append(newStamp)
+        # Follow same procedure as Stamps subclass
+        self._stamps.append(newStamp)
 
     def extend(self, newStampList):
         """Extend DonutStamps instance by appending elements
@@ -124,9 +123,8 @@ class DonutStamps(StampsBase):
         for stamp in newStampList:
             if not isinstance(stamp, DonutStamp):
                 raise ValueError("Can only extend with DonutStamp objects.")
-        # Utilize functionality from upstream (StampsBase) code.
-        stampList = self[:]
-        stampList.extend(newStampList)
+        # Follow same procedure as Stamps subclass
+        self._stamps += newStampList
 
     @classmethod
     def readFits(cls, filename):

--- a/tests/task/test_donutStamps.py
+++ b/tests/task/test_donutStamps.py
@@ -125,6 +125,9 @@ class TestDonutStamps(lsst.utils.tests.TestCase):
     def testAppend(self):
         """Test ability to append to a Stamps object"""
         self.donutStamps.append(self.donutStamps[0])
+        # Check that the length is 1 longer
+        self.assertEqual(len(self.donutStamps), self.nStamps + 1)
+        # Test roundtrip i/o
         self._roundtrip(self.donutStamps)
         # check if appending something other than a DonutStamp raises
         with self.assertRaises(ValueError) as context:
@@ -136,6 +139,9 @@ class TestDonutStamps(lsst.utils.tests.TestCase):
     def testExtend(self):
         donutStamps2 = copy(self.donutStamps)
         self.donutStamps.extend([stamp for stamp in donutStamps2])
+        # Check that the length is twice as long
+        self.assertEqual(len(self.donutStamps), self.nStamps * 2)
+        # Test roundtrip i/o
         self._roundtrip(self.donutStamps)
         # check if extending with something other than a DonutStamps
         # object raises


### PR DESCRIPTION
The `append` and `extend` methods in `task/DonutStamps.py` do not work as they are supposed to and we need to update the tests to capture this and add a fix. This fix could go in ts_wep or we could make a change in `meas_algorithms/Stamps.py` by adding a `@property` decorated `stamps` variable like the one there for `metadata`.