### PR TITLE
Fix donutStamps type error and pipeline error in latest version of stack

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-1.7.6:
+
+-------------
+1.7.6
+-------------
+* Update donutStamp with archive property.
+* Add `LSSTCam/calib` to collections path in test Gen3 pipelines.
+
 .. _lsst.ts.wep-1.7.5:
 
 -------------

--- a/python/lsst/ts/wep/task/DonutStamp.py
+++ b/python/lsst/ts/wep/task/DonutStamp.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass
 
 import lsst.geom
 import lsst.afw.image as afwImage
+import lsst.afw.table as afwTable
+from typing import Optional
 from lsst.meas.algorithms.stamps import AbstractStamp
 
 
@@ -47,9 +49,10 @@ class DonutStamp(AbstractStamp):
     sky_position: lsst.geom.SpherePoint
     centroid_position: lsst.geom.Point2I
     detector_name: str
+    archive_element: Optional[afwTable.io.Persistable] = None
 
     @classmethod
-    def factory(cls, stamp_im, metadata, index):
+    def factory(cls, stamp_im, metadata, index, archive_element=None):
         """This method is needed to service the FITS reader.
         We need a standard interface to construct objects like this.
         Parameters needed to construct this object are passed in via
@@ -65,6 +68,9 @@ class DonutStamp(AbstractStamp):
             needed by the constructor.
         idx : int
             Index into the lists in ``metadata``
+        archive_element : `afwTable.io.Persistable`, optional
+            Archive element (e.g. Transform or WCS) associated with this stamp.
+            (the default is None.)
 
         Returns
         -------
@@ -73,6 +79,7 @@ class DonutStamp(AbstractStamp):
         """
         return cls(
             stamp_im=stamp_im,
+            archive_element=archive_element,
             sky_position=lsst.geom.SpherePoint(
                 lsst.geom.Angle(metadata.getArray("RA_DEG")[index], lsst.geom.degrees),
                 lsst.geom.Angle(metadata.getArray("DEC_DEG")[index], lsst.geom.degrees),

--- a/tests/task/test_estimateZernikesBase.py
+++ b/tests/task/test_estimateZernikesBase.py
@@ -60,7 +60,7 @@ class TestEstimateZernikesBase(lsst.utils.tests.TestCase):
             cleanUpCmd = writeCleanUpRepoCmd(cls.repoDir, cls.runName)
             runProgram(cleanUpCmd)
 
-        collections = "refcats,LSSTCam/raw/all"
+        collections = "refcats,LSSTCam/calib,LSSTCam/raw/all"
         instrument = "lsst.obs.lsst.LsstCam"
         pipelineYaml = os.path.join(testPipelineConfigDir, "testBasePipeline.yaml")
 

--- a/tests/task/test_estimateZernikesCwfsTask.py
+++ b/tests/task/test_estimateZernikesCwfsTask.py
@@ -65,7 +65,7 @@ class TestEstimateZernikesCwfsTask(lsst.utils.tests.TestCase):
             cleanUpCmd = writeCleanUpRepoCmd(cls.repoDir, cls.runName)
             runProgram(cleanUpCmd)
 
-        collections = "refcats,LSSTCam/raw/all"
+        collections = "refcats,LSSTCam/calib,LSSTCam/raw/all"
         instrument = "lsst.obs.lsst.LsstCam"
         pipelineYaml = os.path.join(testPipelineConfigDir, "testCwfsPipeline.yaml")
 

--- a/tests/task/test_estimateZernikesFamTask.py
+++ b/tests/task/test_estimateZernikesFamTask.py
@@ -62,7 +62,7 @@ class TestEstimateZernikesFamTask(lsst.utils.tests.TestCase):
             cleanUpCmd = writeCleanUpRepoCmd(cls.repoDir, cls.runName)
             runProgram(cleanUpCmd)
 
-        collections = "refcats,LSSTCam/raw/all"
+        collections = "refcats,LSSTCam/calib,LSSTCam/raw/all"
         instrument = "lsst.obs.lsst.LsstCam"
         pipelineYaml = os.path.join(testPipelineConfigDir, "testFamPipeline.yaml")
 

--- a/tests/task/test_generateDonutCatalogWcsTask.py
+++ b/tests/task/test_generateDonutCatalogWcsTask.py
@@ -68,7 +68,7 @@ class TestGenerateDonutCatalogWcsTask(unittest.TestCase):
         # Run pipeline command
         runName = "run1"
         instrument = "lsst.obs.lsst.LsstCam"
-        collections = "refcats,LSSTCam/raw/all"
+        collections = "refcats,LSSTCam/calib,LSSTCam/raw/all"
         exposureId = 4021123106001  # Exposure ID for test extra-focal image
         testPipelineConfigDir = os.path.join(self.testDataDir, "pipelineConfigs")
         pipelineYaml = os.path.join(


### PR DESCRIPTION
This fixes `ts_wep` failing on Jenkins as of August 5. Looks like the error is coming from a change in the stamps.py in `meas_algorithms and missing calibration path in the Gen 3 test pipelines.