### PR TITLE
Update stamp rotations to work with CWFS.

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-1.7.8:
+
+-------------
+1.7.8
+-------------
+
+* Update stamp rotations to work with CWFS.
+
 .. _lsst.ts.wep-1.7.7:
 
 -------------

--- a/python/lsst/ts/wep/task/EstimateZernikesCwfsTask.py
+++ b/python/lsst/ts/wep/task/EstimateZernikesCwfsTask.py
@@ -106,12 +106,6 @@ class EstimateZernikesCwfsTask(EstimateZernikesBaseTask):
             "source_flux", ascending=False
         ).reset_index(drop=True)
 
-        # Adjust for display of corner wavefront sensors
-        extraCatalog["centroid_x"] = dimX - extraCatalog["centroid_x"]
-        extraCatalog["centroid_y"] = dimY - extraCatalog["centroid_y"]
-        intraCatalog["centroid_x"] = dimX - intraCatalog["centroid_x"]
-        intraCatalog["centroid_y"] = dimY - intraCatalog["centroid_y"]
-
         # For now take as many pairs of sources as possible
         catLength = np.min([len(extraCatalog), len(intraCatalog)])
 

--- a/tests/task/test_estimateZernikesCwfsTask.py
+++ b/tests/task/test_estimateZernikesCwfsTask.py
@@ -180,8 +180,6 @@ class TestEstimateZernikesCwfsTask(lsst.utils.tests.TestCase):
         testDf["centroid_y"] = np.zeros(5)
         testDf["detector"] = ["R00_SW0", "R44_SW0", "R40_SW1", "R04_SW1", "R22_S11"]
         extraCatalog, intraCatalog = self.task.selectCwfsSources(testDf, (4072, 2000))
-        testDf["centroid_x"] = 4072 - testDf["centroid_x"]
-        testDf["centroid_y"] = 2000 - testDf["centroid_y"]
 
         np.testing.assert_array_equal(extraCatalog.values, testDf.iloc[:2].values[::-1])
         np.testing.assert_array_equal(


### PR DESCRIPTION
Based off the updated `focalplanelayout` file this enables the correct rotations of the CWFS postage stamps.