### PR TITLE
Tweak test to work with latest meas_algorithms update in w_2022_2.

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,15 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-2.0.2:
+
+-------------
+2.0.2
+-------------
+
+* Patch to work with weekly `w_2022_2`:
+    * `loadSkyCircle` no longer returns centroid column, use `loadPixelBox` instead.
+
 .. _lsst.ts.wep-2.0.1:
 
 -------------

--- a/tests/task/test_generateDonutCatalogBase.py
+++ b/tests/task/test_generateDonutCatalogBase.py
@@ -107,16 +107,24 @@ class TestGenerateDonutCatalogBase(unittest.TestCase):
         refObjLoader = self.task.getRefObjLoader(refCatList)
 
         # Check that our refObjLoader loads the available objects
-        # within a given search radius
-        donutCatSmall = refObjLoader.loadSkyCircle(
-            lsst.geom.SpherePoint(0.0, 0.0, lsst.geom.degrees),
-            lsst.geom.Angle(0.5, lsst.geom.degrees),
-            filterName="g",
+        # within a given footprint from a sample exposure
+        testDataId = {
+            "instrument": "LSSTCam",
+            "detector": 94,
+            "exposure": 4021123106001,
+        }
+        testExposure = self.butler.get(
+            "raw", dataId=testDataId, collections="LSSTCam/raw/all"
+        )
+        donutCatSmall = refObjLoader.loadPixelBox(
+            testExposure.getBBox(),
+            testExposure.getWcs(),
+            testExposure.getFilter().getName(),
         )
         fieldObjects = self.task.donutCatalogListToDataFrame(
             [donutCatSmall.refCat, donutCatSmall.refCat], ["R22_S99", "R22_S99"]
         )
-        self.assertEqual(len(fieldObjects), 16)
+        self.assertEqual(len(fieldObjects), 8)
         self.assertCountEqual(
             fieldObjects.columns,
             [


### PR DESCRIPTION
 loadSkyCircle no longer returns centroid column, use loadPixelBox instead.