### PR TITLE
Remove timeMethod deprecation warnings and use static calibration cam…

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-2.1.4:
+
+-------------
+2.1.4
+-------------
+
+* Remove `timeMethod` deprecation warnings and use static calibration camera.
+
 .. _lsst.ts.wep-2.1.3:
 
 -------------

--- a/python/lsst/ts/wep/task/DonutSourceSelectorTask.py
+++ b/python/lsst/ts/wep/task/DonutSourceSelectorTask.py
@@ -26,6 +26,7 @@ from sklearn.neighbors import NearestNeighbors
 
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
+from lsst.utils.timer import timeMethod
 from lsst.meas.algorithms.sourceSelector import (
     _getFieldFromCatalog,
 )
@@ -118,7 +119,7 @@ class DonutSourceSelectorTask(pipeBase.Task):
             sourceCat=sourceCat[result.selected], selected=result.selected
         )
 
-    @pipeBase.timeMethod
+    @timeMethod
     def selectSources(self, sourceCat, bbox):
         """
         Run the source selection algorithm and return the indices to keep

--- a/python/lsst/ts/wep/task/EstimateZernikesBase.py
+++ b/python/lsst/ts/wep/task/EstimateZernikesBase.py
@@ -27,6 +27,7 @@ import lsst.pipe.base as pipeBase
 import lsst.pex.config as pexConfig
 from lsst.daf.base import PropertyList
 from lsst.pipe.base import connectionTypes
+from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 
 from lsst.ts.wep.WfEstimator import WfEstimator
 from lsst.ts.wep.Utility import getConfigDir, DonutTemplateType, DefocalType
@@ -57,6 +58,7 @@ class EstimateZernikesBaseConnections(
         doc="Input camera to construct complete exposures.",
         dimensions=["instrument"],
         isCalibration=True,
+        lookupFunction=lookupStaticCalibration,
     )
     donutStampsExtra = connectionTypes.Output(
         doc="Extra-focal Donut Postage Stamp Images",

--- a/python/lsst/ts/wep/task/EstimateZernikesCwfsTask.py
+++ b/python/lsst/ts/wep/task/EstimateZernikesCwfsTask.py
@@ -27,6 +27,7 @@ import lsst.afw.cameraGeom
 import lsst.pipe.base as pipeBase
 import lsst.afw.image as afwImage
 import lsst.obs.lsst as obs_lsst
+from lsst.utils.timer import timeMethod
 from lsst.pipe.base import connectionTypes
 
 from lsst.ts.wep.Utility import DefocalType
@@ -168,6 +169,7 @@ class EstimateZernikesCwfsTask(EstimateZernikesBaseTask):
                 outputs.outputZernikesAvg, outputRefs.outputZernikesAvg[extraListIdx]
             )
 
+    @timeMethod
     def run(
         self,
         exposures: typing.List[afwImage.Exposure],

--- a/python/lsst/ts/wep/task/EstimateZernikesScienceSensorTask.py
+++ b/python/lsst/ts/wep/task/EstimateZernikesScienceSensorTask.py
@@ -26,6 +26,7 @@ import pandas as pd
 import lsst.afw.cameraGeom
 import lsst.pipe.base as pipeBase
 import lsst.afw.image as afwImage
+from lsst.utils.timer import timeMethod
 from lsst.pipe.base import connectionTypes
 
 from lsst.ts.wep.Utility import DefocalType
@@ -161,6 +162,7 @@ class EstimateZernikesScienceSensorTask(EstimateZernikesBaseTask):
 
         return extraExpIdx, intraExpIdx
 
+    @timeMethod
     def run(
         self,
         exposures: typing.List[afwImage.Exposure],

--- a/python/lsst/ts/wep/task/GenerateDonutCatalogOnlineTask.py
+++ b/python/lsst/ts/wep/task/GenerateDonutCatalogOnlineTask.py
@@ -24,6 +24,7 @@ import pandas as pd
 
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
+from lsst.utils.timer import timeMethod
 from lsst.meas.algorithms import (
     LoadIndexedReferenceObjectsTask,
     ReferenceSourceSelectorTask,
@@ -101,7 +102,7 @@ class GenerateDonutCatalogOnlineTask(pipeBase.Task):
         if self.config.doDonutSelection:
             self.makeSubtask("donutSelector")
 
-    @pipeBase.timeMethod
+    @timeMethod
     def run(self, bbox, wcs):
         """Get the data from the reference catalog only from the
         shards of the reference catalogs that overlap our pointing.

--- a/python/lsst/ts/wep/task/GenerateDonutCatalogWcsTask.py
+++ b/python/lsst/ts/wep/task/GenerateDonutCatalogWcsTask.py
@@ -23,11 +23,13 @@ import os
 import typing
 import warnings
 import pandas as pd
+
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 import lsst.afw.image as afwImage
 import lsst.afw.table as afwTable
 import lsst.pipe.base.connectionTypes as connectionTypes
+from lsst.utils.timer import timeMethod
 from lsst.meas.algorithms import ReferenceObjectLoader, LoadReferenceObjectsConfig
 from lsst.meas.algorithms.sourceSelector import ReferenceSourceSelectorTask
 from lsst.ts.wep.task.DonutSourceSelectorTask import DonutSourceSelectorTask
@@ -225,6 +227,7 @@ class GenerateDonutCatalogWcsTask(pipeBase.PipelineTask):
 
         return fieldObjects
 
+    @timeMethod
     def run(
         self,
         refCatalogs: typing.List[afwTable.SimpleCatalog],

--- a/tests/task/test_estimateZernikesCwfsTask.py
+++ b/tests/task/test_estimateZernikesCwfsTask.py
@@ -66,9 +66,9 @@ class TestEstimateZernikesCwfsTask(lsst.utils.tests.TestCase):
             runProgram(cleanUpCmd)
 
         # Point to the collections for the reference catalogs,
-        # the raw images and the camera model in
-        # calib/unbounded that comes from `butler write-curated-calibrations`
-        collections = "refcats,LSSTCam/calib/unbounded,LSSTCam/raw/all"
+        # the raw images and the camera model in the calib directory
+        # that comes from `butler write-curated-calibrations`.
+        collections = "refcats,LSSTCam/calib,LSSTCam/raw/all"
         instrument = "lsst.obs.lsst.LsstCam"
         cls.cameraName = "LSSTCam"
         pipelineYaml = os.path.join(testPipelineConfigDir, "testCwfsPipeline.yaml")

--- a/tests/task/test_estimateZernikesScienceSensorTask.py
+++ b/tests/task/test_estimateZernikesScienceSensorTask.py
@@ -62,7 +62,10 @@ class TestEstimateZernikesScienceSensorTask(lsst.utils.tests.TestCase):
             cleanUpCmd = writeCleanUpRepoCmd(cls.repoDir, cls.runName)
             runProgram(cleanUpCmd)
 
-        collections = "refcats,LSSTCam/calib/unbounded,LSSTCam/raw/all"
+        # Point to the collections for the reference catalogs,
+        # the raw images and the camera model in the calib directory
+        # that comes from `butler write-curated-calibrations`.
+        collections = "refcats,LSSTCam/calib,LSSTCam/raw/all"
         instrument = "lsst.obs.lsst.LsstCam"
         cls.cameraName = "LSSTCam"
         pipelineYaml = os.path.join(testPipelineConfigDir, "testFamPipeline.yaml")

--- a/ups/ts_wep.table
+++ b/ups/ts_wep.table
@@ -9,6 +9,7 @@ setupRequired(daf_persistence)
 setupRequired(afw)
 setupRequired(phosim_utils)
 setupRequired(ctrl_mpexec)
+setupRequired(cp_pipe)
 
 # The following is boilerplate for all packages.
 # See https://dmtn-001.lsst.io for details on LSST_LIBRARY_PATH.


### PR DESCRIPTION
…era. Add cp_pipe to requirements in `ups/ts_wep.table`.