### PR TITLE
tickets/DM-34312: Optimize CWFS algorithms

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-2.3.7:
+
+-------------
+2.3.7
+-------------
+
+* Optimize CWFS algorithms.
+
 .. _lsst.ts.wep-2.3.6:
 
 -------------

--- a/python/lsst/ts/wep/cwfs/Algorithm.py
+++ b/python/lsst/ts/wep/cwfs/Algorithm.py
@@ -974,8 +974,19 @@ class Algorithm(object):
             ySensor = ySensor * self.cMask
 
             # Create the F matrix and Zernike-related matrixes
+
+            # Get Zernike and gradient bases from cache.  These are each
+            # (nzk, npix, npix) arrays, with the first dimension indicating
+            # the Noll index.
             zk, dzkdx, dzkdy = self._zernikeBasisCache()
+
+            # Eqn. (19) from Xin et al., Appl. Opt. 54, 9045-9054 (2015).
+            # F_j = \int (d_z I) Z_j d_Omega
             F = np.tensordot(dI, zk, axes=((0, 1), (1, 2))) * dOmega
+            # Eqn. (20) from Xin et al., Appl. Opt. 54, 9045-9054 (2015).
+            # M_ij = \int I (grad Z_j) . (grad Z_i) d_Omega
+            #      =   \int I (dZ_i/dx) (dZ_j/dx) d_Omega
+            #        + \int I (dZ_i/dy) (dZ_j/dy) d_Omega
             Mij = np.einsum("ab,iab,jab->ij", I0, dzkdx, dzkdx)
             Mij += np.einsum("ab,iab,jab->ij", I0, dzkdy, dzkdy)
             Mij *= dOmega / (apertureDiameter / 2.0) ** 2

--- a/python/lsst/ts/wep/cwfs/Algorithm.py
+++ b/python/lsst/ts/wep/cwfs/Algorithm.py
@@ -346,7 +346,7 @@ class Algorithm(object):
         return compSequence
 
     def _extend1dArray(self, origArray, targetLength):
-        """Extend the 1D original array to the taget length.
+        """Extend the 1D original array to the target length.
 
         The extended value will be the final element of original array. Nothing
         will be done if the input array is not 1D or its length is less than
@@ -378,7 +378,7 @@ class Algorithm(object):
         the pupil mask.
 
         It is noted that in Fast Fourier transform (FFT) algorithm, it is also
-        the width of Neuman boundary where the derivative of the wavefront is
+        the width of Neumann boundary where the derivative of the wavefront is
         set to zero
 
         Returns
@@ -397,7 +397,7 @@ class Algorithm(object):
         Returns
         -------
         int
-            FFT pad dimention.
+            FFT pad dimension.
         """
 
         fftDim = int(self.algoParamFile.getSetting("fftDimension"))
@@ -548,7 +548,7 @@ class Algorithm(object):
             Optical model. It can be "paraxial", "onAxis", or "offAxis".
         tol : float, optional
             Tolerance of difference of coefficients of Zk polynomials compared
-            with the previours iteration. (the default is 1e-3.)
+            with the previous iteration. (the default is 1e-3.)
         """
 
         # To have the iteration time initiated from global variable is to
@@ -658,7 +658,7 @@ class Algorithm(object):
             Optical model. It can be "paraxial", "onAxis", or "offAxis".
         tol : float, optional
             Tolerance of difference of coefficients of Zk polynomials compared
-            with the previours iteration. (the default is 1e-3.)
+            with the previous iteration. (the default is 1e-3.)
 
         Returns
         -------
@@ -774,7 +774,7 @@ class Algorithm(object):
         else:
             # Once we run into caustic, stop here, results may be close to real
             # aberration.
-            # Continuation may lead to disatrous results.
+            # Continuation may lead to disastrous results.
             self.converge[:, jj] = self.converge[:, jj - 1]
 
         # Record the coefficients of normal/ annular Zernike polynomials after
@@ -829,7 +829,7 @@ class Algorithm(object):
             Estimated wavefront.
         """
 
-        # Calculate the aperature pixel size
+        # Calculate the aperture pixel size
         apertureDiameter = self._inst.getApertureDiameter()
         sensorFactor = self._inst.getSensorFactor()
         dimOfDonut = self._inst.getDimOfDonutOnSensor()
@@ -1093,7 +1093,7 @@ class Algorithm(object):
         # Check the condition of images
         I1image, I2image = self._checkImageDim(I1, I2)
 
-        # Calculate the central image and differential iamge
+        # Calculate the central image and differential image
         I0 = (I1image + I2image) / 2
         dI = I2image - I1image
 
@@ -1162,7 +1162,7 @@ class Algorithm(object):
         """
 
         # Get the overlap region of mask for intra- and extra-focal images.
-        # This is to avoid the anormalous signal due to difference in
+        # This is to avoid the anomalous signal due to difference in
         # vignetting.
         self.pMask = I1.getPaddedMask() * I2.getPaddedMask()
         self.cMask = I1.getNonPaddedMask() * I2.getNonPaddedMask()

--- a/python/lsst/ts/wep/cwfs/Algorithm.py
+++ b/python/lsst/ts/wep/cwfs/Algorithm.py
@@ -940,19 +940,9 @@ class Algorithm(object):
                 # other Zk's calculation
                 zcCol[ii] = 0
 
-            # Calculate Mij matrix, need to check the stability of integration
-            # and symmetry later
-            Mij = np.zeros([numTerms, numTerms])
-            for ii in range(numTerms):
-                for jj in range(numTerms):
-                    Mij[ii, jj] = np.sum(
-                        I0
-                        * (
-                            dZidx[ii, :, :].squeeze() * dZidx[jj, :, :].squeeze()
-                            + dZidy[ii, :, :].squeeze() * dZidy[jj, :, :].squeeze()
-                        )
-                    )
-            Mij = dOmega / (apertureDiameter / 2.0) ** 2 * Mij
+            Mij = np.einsum("ab,iab,jab->ij", I0, dZidx, dZidx)
+            Mij += np.einsum("ab,iab,jab->ij", I0, dZidy, dZidy)
+            Mij *= dOmega / (apertureDiameter / 2.0) ** 2
 
             # Calculate dz
             focalLength = self._inst.getFocalLength()

--- a/python/lsst/ts/wep/cwfs/CompensableImage.py
+++ b/python/lsst/ts/wep/cwfs/CompensableImage.py
@@ -455,10 +455,7 @@ class CompensableImage(object):
         ip = RectBivariateSpline(yp[:, 0], xp[0, :], self.getImg(), kx=1, ky=1)
 
         # Construct the projected image by the interpolation
-        lutIp = np.zeros(lutxp.shape[0] * lutxp.shape[1])
-        for ii, (xx, yy) in enumerate(zip(lutxp.ravel(), lutyp.ravel())):
-            lutIp[ii] = ip(yy, xx)
-        lutIp = lutIp.reshape(lutxp.shape)
+        lutIp = ip(lutyp, lutxp, grid=False)
 
         # Calculate the image on focal plane with compensation based on flux
         # conservation

--- a/python/lsst/ts/wep/cwfs/CompensableImage.py
+++ b/python/lsst/ts/wep/cwfs/CompensableImage.py
@@ -893,7 +893,7 @@ class CompensableImage(object):
         luty : numpy.ndarray
             Y-coordinate on pupil plane.
         onepixel : float
-            Exteneded delta radius.
+            Extended delta radius.
         ca : float
             Center of outer ring on the pupil plane.
         cb : float
@@ -934,8 +934,8 @@ class CompensableImage(object):
         return lutx, luty
 
     def _approximateExtendedXY(self, lutx, luty, cenX, cenY, innerR, outerR, config):
-        """Calculate the x, y-cooridnate on puil plane in the extended ring
-        area by the linear approxination, which is used in the off-axis
+        """Calculate the x, y-coordinate on pupil plane in the extended ring
+        area by the linear approximation, which is used in the off-axis
         correction.
 
         Parameters
@@ -964,7 +964,7 @@ class CompensableImage(object):
             Y-coordinate of extended ring area on pupil plane.
         """
 
-        # Catculate the distance to rotated center of boundary ring
+        # Calculate the distance to rotated center of boundary ring
         lutr = np.sqrt((lutx - cenX) ** 2 + (luty - cenY) ** 2)
 
         # Define NaN to be 999 for the comparison in the following step
@@ -985,7 +985,7 @@ class CompensableImage(object):
             # Get the index that the related distance is smaller than innerR
             idxout = tmp < innerR
 
-        # Put the x, y-coordiate to be NaN if it is inside/ outside the pupil
+        # Put the x, y-coordinate to be NaN if it is inside/ outside the pupil
         # that is after the off-axis correction.
         lutx[idxout] = np.nan
         luty[idxout] = np.nan
@@ -1054,7 +1054,7 @@ class CompensableImage(object):
             Image to be centered with the template. The input image needs to
             be a n-by-n matrix.
         template : numpy.array
-            Template image to have the same dimention as the input image
+            Template image to have the same dimension as the input image
             ('img'). The center of template is the position of input image
             tries to align with.
         window : int, optional
@@ -1073,7 +1073,7 @@ class CompensableImage(object):
 
         # Calculate the shifts of center
 
-        # Only consider the shifts in a cetrain window (range)
+        # Only consider the shifts in a certain window (range)
         # Align the input image to the center of template
         length = template.shape[0]
         center = length // 2
@@ -1085,7 +1085,7 @@ class CompensableImage(object):
         idx = np.argmax(corr * mask)
 
         # The above 'idx' is an interger. Need to rematch it to the
-        # two-dimention position (x and y)
+        # two-dimension position (x and y)
         xmatch = idx % length
         ymatch = idx // length
 
@@ -1099,7 +1099,7 @@ class CompensableImage(object):
         """Set the coefficients of off-axis correction for x, y-projection of
         intra- and extra-image.
 
-        This is for the mapping of coordinate from the telescope apearature to
+        This is for the mapping of coordinate from the telescope aperture to
         defocal image plane.
 
         Parameters
@@ -1139,7 +1139,7 @@ class CompensableImage(object):
         self.offAxisOffset = offset
 
     def _getOffAxisCorrSingle(self, confFile):
-        """Get the image-related pamameters for the off-axis distortion by the
+        """Get the image-related parameters for the off-axis distortion by the
         linear approximation with a series of fitted parameters with LSST
         ZEMAX model.
 
@@ -1181,7 +1181,7 @@ class CompensableImage(object):
         return corr_coeff, offset
 
     def _interpMaskParam(self, fieldX, fieldY, maskParam):
-        """Get the mask-related pamameters for the off-axis distortion and
+        """Get the mask-related parameters for the off-axis distortion and
         vignetting correction by the linear approximation with a series of
         fitted parameters with LSST ZEMAX model.
 


### PR DESCRIPTION
I found four optimizations for CWFS algorithms.  Three of these are just replacing python for-loops with vectorized numpy instructions.  The last is caching a repeated Zernike+gradient calculation.  Timing before/after shows about a 3x speed improvement for Zernike estimation.