### PR TITLE
Tickets/dm 34846: revert some changes

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -12,7 +12,8 @@ Version History
 2.5.0
 -------------
 
-* Update cMask, pMask to mask_pupil, mask_comp.
+* Update names of cMask to mask_comp (padded), pMask to mask_pupil (non-padded)
+* Correct output of getPaddedMask to mask_comp, getNonPaddedMask to mask_pupil
 
 .. _lsst.ts.wep-2.4.4:
 

--- a/tests/cwfs/test_algorithm.py
+++ b/tests/cwfs/test_algorithm.py
@@ -200,7 +200,7 @@ class TestAlgorithm(unittest.TestCase):
 
         wavefrontMapResidual = self.algoExp.getWavefrontMapResidual()
         wavefrontMapResidual[np.isnan(wavefrontMapResidual)] = 0
-        self.assertLess(np.sum(np.abs(wavefrontMapResidual)), 2.6e-6)
+        self.assertLess(np.sum(np.abs(wavefrontMapResidual)), 2.5e-6)
 
     def testItr0(self):
 
@@ -310,7 +310,7 @@ class TestAlgorithm(unittest.TestCase):
         self.algoFft.runIt(self.I1, self.I2, self.opticalModel, tol=1e-3)
 
         zk = self.algoFft.getZer4UpInNm()
-        self.assertEqual(int(zk[7]), -191)
+        self.assertEqual(int(zk[7]), -192)
 
 
 if __name__ == "__main__":

--- a/tests/cwfs/test_multiImgs.py
+++ b/tests/cwfs/test_multiImgs.py
@@ -43,8 +43,8 @@ class TestWepWithMultiImgs(BaseCwfsTestCase, unittest.TestCase):
         )
 
         # Set the tolerance
-        self.tolMax = 8.5
-        self.tolRms = 3
+        self.tolMax = 4
+        self.tolRms = 1
 
         # Record the start time
         self.startTime = time.perf_counter()

--- a/tests/test_wfEstimator.py
+++ b/tests/test_wfEstimator.py
@@ -141,7 +141,7 @@ class TestWfEstimator(unittest.TestCase):
         ]
         zer4UpNm = self.wfsEst.calWfsErr()
         self.assertAlmostEqual(
-            np.sum(np.abs(zer4UpNm - np.array(wfsError))), 28.38981929, places=7
+            np.sum(np.abs(zer4UpNm - np.array(wfsError))), 6.95092306, places=7
         )
 
         # Test to reset the data


### PR DESCRIPTION
It turns out that the algorithm worked with pMask having the non-padded mask, and cMask having the padded mask, despite them being inherited via 

     self.pMask = I1.getPaddedMask() * I2.getPaddedMask()

but since previously `getPaddedMask` returned `pMask` which was `non-padded`,  it ended up with `pMask` working as `mask_pupil` despite  being inherited from `getPaddedMask`.

Thus now just like in `Compensable` , `pMask` --> `mask_pupil` ( "non-padded"), and `cMask` --> `mask_comp` ("padded"), and the what makes it consistent is that `mask_pupil` is inherited from `getNonPaddedMask` (which returns indeed `mask_pupil`. 