### PR TITLE
DM-35860: Update science sensor tasks to get focusZ from exposure visitInfo

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-2.5.4:
+
+-------------
+2.5.4
+-------------
+
+* Update science sensor and LATISS tasks to get focusZ from exposure visitInfo instead of metadata after update in DM-35186.
+
 .. _lsst.ts.wep-2.5.3:
 
 -------------

--- a/python/lsst/ts/wep/task/CutOutDonutsScienceSensorTask.py
+++ b/python/lsst/ts/wep/task/CutOutDonutsScienceSensorTask.py
@@ -89,7 +89,7 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
         """
 
         exposures = butlerQC.get(inputRefs.exposures)
-        focusZVals = [exp.getMetadata()["FOCUSZ"] for exp in exposures]
+        focusZVals = [exp.getInfo().getVisitInfo().focusZ for exp in exposures]
         extraIdx, intraIdx = self.assignExtraIntraIdx(focusZVals[0], focusZVals[1])
 
         donutCats = butlerQC.get(inputRefs.donutCatalog)
@@ -153,9 +153,11 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
         camera: lsst.afw.cameraGeom.Camera,
     ) -> pipeBase.Struct:
 
-        # Get exposure metadata to find which is extra and intra
-        focusZ0 = exposures[0].getMetadata()["FOCUSZ"]
-        focusZ1 = exposures[1].getMetadata()["FOCUSZ"]
+        # Get exposure visitInfo to find which is extra and intra
+        visitInfo_0 = exposures[0].getInfo().getVisitInfo()
+        visitInfo_1 = exposures[1].getInfo().getVisitInfo()
+        focusZ0 = visitInfo_0.focusZ
+        focusZ1 = visitInfo_1.focusZ
 
         extraExpIdx, intraExpIdx = self.assignExtraIntraIdx(focusZ0, focusZ1)
 

--- a/python/lsst/ts/wep/task/EstimateZernikesLatissTask.py
+++ b/python/lsst/ts/wep/task/EstimateZernikesLatissTask.py
@@ -149,9 +149,11 @@ class EstimateZernikesLatissTask(EstimateZernikesBaseTask):
         camera: lsst.afw.cameraGeom.Camera,
     ) -> pipeBase.Struct:
 
-        # Get exposure metadata to find which is extra and intra
-        focusZ0 = exposures[0].getMetadata()["FOCUSZ"]
-        focusZ1 = exposures[1].getMetadata()["FOCUSZ"]
+        # Get exposure visitInfo to find which is extra and intra
+        visitInfo_0 = exposures[0].getInfo().getVisitInfo()
+        visitInfo_1 = exposures[1].getInfo().getVisitInfo()
+        focusZ0 = visitInfo_0.focusZ
+        focusZ1 = visitInfo_1.focusZ
 
         extraExpIdx, intraExpIdx = self.assignExtraIntraIdx(focusZ0, focusZ1)
 

--- a/python/lsst/ts/wep/task/EstimateZernikesScienceSensorTask.py
+++ b/python/lsst/ts/wep/task/EstimateZernikesScienceSensorTask.py
@@ -142,9 +142,11 @@ class EstimateZernikesScienceSensorTask(EstimateZernikesBaseTask):
         camera: lsst.afw.cameraGeom.Camera,
     ) -> pipeBase.Struct:
 
-        # Get exposure metadata to find which is extra and intra
-        focusZ0 = exposures[0].getMetadata()["FOCUSZ"]
-        focusZ1 = exposures[1].getMetadata()["FOCUSZ"]
+        # Get exposure visitInfo to find which is extra and intra
+        visitInfo_0 = exposures[0].getInfo().getVisitInfo()
+        visitInfo_1 = exposures[1].getInfo().getVisitInfo()
+        focusZ0 = visitInfo_0.focusZ
+        focusZ1 = visitInfo_1.focusZ
 
         extraExpIdx, intraExpIdx = self.assignExtraIntraIdx(focusZ0, focusZ1)
 

--- a/tests/task/test_calcZernikesTaskScienceSensor.py
+++ b/tests/task/test_calcZernikesTaskScienceSensor.py
@@ -72,7 +72,9 @@ class TestCalcZernikesTaskScienceSensor(lsst.utils.tests.TestCase):
         pipeCmd = writePipetaskCmd(
             cls.repoDir, cls.runName, instrument, collections, pipelineYaml=pipelineYaml
         )
-        pipeCmd += ' -d "detector NOT IN (191, 192, 195, 196, 199, 200, 203, 204)"'
+        # Make sure we are using the right exposure+detector combinations
+        pipeCmd += ' -d "exposure IN (4021123106001, 4021123106002) AND '
+        pipeCmd += 'detector NOT IN (191, 192, 195, 196, 199, 200, 203, 204)"'
         runProgram(pipeCmd)
 
     @classmethod


### PR DESCRIPTION
Update science sensor tasks to get focusZ from exposure visitInfo instead of metadata after update in DM-35186.