### PR TITLE
Tickets/DM-36154: Algorithm history; symmetry with respect to I1, I2.

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -5,6 +5,17 @@
 ##################
 Version History
 ##################
+  
+.. _lsst.ts.wep-3.1.0:
+
+-------------
+3.1.0
+-------------
+
+* Added a history to the Algorithm class that stores intermediate products of the algorithm (see `Algorithm.getHistory()`).
+* Fixed the algorithm so that it is once again symmetric with respect to I1 and I2.
+  This involved simplifying the way that mask and image orientation are handled for the extrafocal image (see below).
+* Added the option to create masks in the orientation of the original images by setting `compensated=False` in `CompensableImage.makeMask()`.
 
 .. _lsst.ts.wep-3.0.1:
 
@@ -13,7 +24,7 @@ Version History
 -------------
 
 * Fix ``test_generateDonutCatalogWcsTask.py`` to work with more recent versions of the DM stack.
-
+  
 .. _lsst.ts.wep-3.0.0:
 
 -------------


### PR DESCRIPTION
### Algorithm Log:
This PR adds internal logging to the algorithm, which you can see in action in [this notebook](https://gist.github.com/jfcrenshaw/751848194c27a1e79b6f51d20193a48c).

There is logging for the outer and inner loops of the algorithm, including the initial images, the compensated images, the masks, the estimated zernikes and wavefronts, and the reason for terminating the outer loop.

You can set the `debugLevel` at which each object is logged. I have set everything to be logged when `debugLevel>=1`, but we can change this if people want.

*The algorithm log is not saved in the butler when running the pipeline tasks. I will open a separate ticket aimed at getting the log integrated in the pipeline tasks.*

### Other changes:

In the process of setting up this logging, I restored the symmetry of the algorithm with respect to `I1` and `I2`. This required two things:

#### 1. Simplifying rotations of the masks and images

After this update, masks match the orientations of the original images (i.e. the orientation of the extrafocal and intrafocal masks are different by 180 deg, because the orientation of the corresponding images are different by 180 deg).

The orientation of the extrafocal image is made to match the orientation of the intrafocal image during image compensation, which happens while running the algorithm. The algorithm then applies masks to the compensated images. For this reason, when the algorithm creates the masks, it calls `makeMask(..., compensated=True)`. This causes the masks to match the orientation of the compensated images (i.e. the extrafocal mask is now rotated 180 deg to match the orientation of the compensated extrafocal image).

#### 2. Simplified and fixed the calculation of `I0` and `dI`

The algorithm requires the calculation of the mean image, `I0`, and the difference image, `dI`. The "exp" and "fft" algorithms were both doing this, using separate bits of code. I removed the code duplication, so both algorithm modes are using the same method to calculate these images (i.e. `Algorithm._getdIandI0`).

The sign of the difference image, `dI`, is sensitive to which image is extrafocal and which image is intrafocal. I fixed this by introducing an additional minus sign whenever `I2` is extrafocal.