### PR TITLE
Tickets/DM-36304: remove imageCoCenter

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,15 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-3.1.4:
+
+-------------
+3.1.4
+-------------
+
+* Remove imageCoCenter step from Algorithm.
+* Add DeprecationWarning that imageCoCenter function in CompensableImage will be removed after January 2023.
+
 .. _lsst.ts.wep-3.1.3:
 
 -------------

--- a/python/lsst/ts/wep/cwfs/Algorithm.py
+++ b/python/lsst/ts/wep/cwfs/Algorithm.py
@@ -811,11 +811,6 @@ class Algorithm(object):
                     I1.setOffAxisCorr(self._inst, offAxisPolyOrder)
                     I2.setOffAxisCorr(self._inst, offAxisPolyOrder)
 
-                # Cocenter the images to the center referenced to fieldX and
-                # fieldY. Need to check the availability of this.
-                I1.imageCoCenter(self._inst, debugLevel=self.debugLevel)
-                I2.imageCoCenter(self._inst, debugLevel=self.debugLevel)
-
                 # Update the self-initial image
                 I1.updateImgInit()
                 I2.updateImgInit()

--- a/python/lsst/ts/wep/cwfs/CompensableImage.py
+++ b/python/lsst/ts/wep/cwfs/CompensableImage.py
@@ -23,6 +23,7 @@ __all__ = ["CompensableImage"]
 
 import os
 import re
+import warnings
 import numpy as np
 
 from scipy.ndimage import generate_binary_structure, iterate_structure
@@ -273,7 +274,6 @@ class CompensableImage(object):
     def imageCoCenter(self, inst, fov=3.5, debugLevel=0):
         """Shift the weighting center of donut to the center of reference
         image with the correction of projection of fieldX and fieldY.
-
         Parameters
         ----------
         inst : Instrument
@@ -285,6 +285,11 @@ class CompensableImage(object):
             information shows more. It can be 0, 1, 2, or 3. (the default is
             0.)
         """
+
+        warnings.warn(
+            "This function is deprecated.  Will be removed after January 2023.",
+            DeprecationWarning,
+        )
 
         # Calculate the weighting center (x, y) and radius
         x1, y1 = self._image.getCenterAndR()[0:2]

--- a/tests/cwfs/test_compensableImage.py
+++ b/tests/cwfs/test_compensableImage.py
@@ -200,6 +200,9 @@ class TestCompensableImage(unittest.TestCase):
         self.assertEqual(int(xc), 63)
         self.assertEqual(int(yc), 63)
 
+        with self.assertWarns(DeprecationWarning):
+            self.wfsImg.imageCoCenter(self.inst)
+
     def testCompensate(self):
 
         # Generate a fake algorithm class
@@ -225,7 +228,6 @@ class TestCompensableImage(unittest.TestCase):
         for wfsImg in [wfsImgIntra, wfsImgExtra]:
             wfsImg.makeMask(self.inst, self.opticalModel, boundaryT, 1)
             wfsImg.setOffAxisCorr(self.inst, offAxisCorrOrder)
-            wfsImg.imageCoCenter(self.inst)
             wfsImg.compensate(self.inst, algo, zcCol, self.opticalModel)
 
         # Get the common region


### PR DESCRIPTION
Given the results of https://jira.lsstcorp.org/browse/DM-36714  and https://jira.lsstcorp.org/browse/DM-36304 , I open this PR to remove the `imageCoCenter` step, given that it makes no difference on the result of the calculation, and therefore saves extra computational time. To summarize these tickets, it has been found that the amount of shift imparted by `imageCoCenter` , being by design `<6` pixels (assuming defocal offset of `1.5` mm and pixels size `10` microns), makes no difference on the recovered Zernikes. This is because this minute shift is counteracted for in the `compensate` step where images are  transformed to the pupil plane, and `recentered`, to match the center of the projection template to the center of each donut. Simulations showed that the shift imparted  by `imageCoCenter` would have to exceed `~9` pixels to make any difference to the results of running the CWFS algorithm. 