### PR TITLE
Add default value to DonutStamp for DFC_DIST.

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-3.1.3:
+
+-------------
+3.1.3
+-------------
+
+* Added default value to DonutStamp for DFC_DIST to allow the butler to read DonutStamp from repositories created with older versions of ts_wep.
+
 .. _lsst.ts.wep-3.1.2:
 
 -------------
@@ -23,7 +31,7 @@ Version History
 * Fix tests pipeline yaml files updating the ISR setting to use 'MEDIAN' for overscan fit type.
 * Remove obsolete _generateTestExposures.
 * Fix `test_generateDonutDirectDetectTask.py`
-  
+
 .. _lsst.ts.wep-3.1.0:
 
 -------------
@@ -42,7 +50,7 @@ Version History
 -------------
 
 * Fix ``test_generateDonutCatalogWcsTask.py`` to work with more recent versions of the DM stack.
-  
+
 .. _lsst.ts.wep-3.0.0:
 
 -------------

--- a/python/lsst/ts/wep/task/DonutStamp.py
+++ b/python/lsst/ts/wep/task/DonutStamp.py
@@ -137,7 +137,11 @@ class DonutStamp(AbstractStamp):
             # Need to convert to DefocalType
             defocal_type=metadata.getArray("DFC_TYPE")[index],
             # "DFC_DIST" stands for defocal distance
-            defocal_distance=metadata.getArray("DFC_DIST")[index],
+            # If this is an old version of the stamps without a defocal
+            # distance set this to default value of 1.5 mm.
+            defocal_distance=metadata.getArray("DFC_DIST")[index]
+            if metadata.get("DFC_DIST") is not None
+            else 1.5,
         )
 
     def getCamera(self):


### PR DESCRIPTION
Added default value to DonutStamp for DFC_DIST to allow the butler to read DonutStamp from repositories created with older versions of ts_wep.