### PR TITLE
Tickets/DM-37593: update UPS table

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-4.0.1:
+
+-------------
+4.0.1
+-------------
+
+* Remove Gen2 daf_persistence from UPS table.
+
 .. _lsst.ts.wep-4.0.0:
 
 -------------

--- a/ups/ts_wep.table
+++ b/ups/ts_wep.table
@@ -5,7 +5,6 @@
 setupRequired(sconsUtils)
 setupRequired(utils)
 setupRequired(obs_lsst)
-setupRequired(daf_persistence)
 setupRequired(afw)
 setupRequired(ctrl_mpexec)
 setupRequired(cp_pipe)


### PR DESCRIPTION
Removing Gen2 `daf_persistence` requirement from the UPS table.