### PR TITLE
tickets/DM-37821: Use nan string instead of None in DonutStamps.py 

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-4.2.1:
+
+-------------
+4.2.1
+-------------
+
+* Use nan string instead of None so we can convert to float and use writeFits method in DonutStamps successfully and save in butler.
+
 .. _lsst.ts.wep-4.2.0:
 
 -------------

--- a/python/lsst/ts/wep/WfEstimator.py
+++ b/python/lsst/ts/wep/WfEstimator.py
@@ -224,9 +224,6 @@ class WfEstimator(object):
         elif defocalType == DefocalType.Extra:
             img = self.imgExtra
 
-        if blendOffsets is None:
-            blendOffsets = [[], []]
-
         img.setImg(
             fieldXY,
             defocalType,

--- a/python/lsst/ts/wep/cwfs/Algorithm.py
+++ b/python/lsst/ts/wep/cwfs/Algorithm.py
@@ -802,7 +802,9 @@ class Algorithm(object):
                     sys.exit()
 
                 # Check for blends
-                if (len(I1.blendOffsetX) > 0) or (len(I2.blendOffsetX) > 0):
+                if (np.sum(np.isnan(I1.blendOffsetX)) == 0) and (
+                    np.sum(np.isnan(I2.blendOffsetX)) == 0
+                ):
                     self.blend_exists = True
 
                 # Create the pupil masks

--- a/python/lsst/ts/wep/cwfs/CompensableImage.py
+++ b/python/lsst/ts/wep/cwfs/CompensableImage.py
@@ -69,8 +69,8 @@ class CompensableImage(object):
 
         # Blended coordinates in pixels relative
         # to central donut
-        self.blendOffsetX = list()
-        self.blendOffsetY = list()
+        self.blendOffsetX = None
+        self.blendOffsetY = None
 
         # Initial image before doing the compensation
         self.image0 = None
@@ -238,7 +238,7 @@ class CompensableImage(object):
         self._checkImgShape()
 
         if blendOffsets is None:
-            blendOffsets = [[], []]
+            blendOffsets = np.array([["nan"], ["nan"]], dtype=float)
 
         self.fieldX, self.fieldY = fieldXY
         self.defocalType = defocalType
@@ -1586,7 +1586,7 @@ class CompensableImage(object):
         )
 
         # Add blended donuts if they exist
-        if len(self.blendOffsetX) > 0:
+        if np.sum(np.isnan(self.blendOffsetX)) == 0:
             newMaskPupil = self.createBlendedCoadd(self.mask_pupil, blendPadding)
             newMaskComp = self.createBlendedCoadd(self.mask_comp, blendPadding)
             self.mask_pupil = newMaskPupil

--- a/python/lsst/ts/wep/task/CalcZernikesTask.py
+++ b/python/lsst/ts/wep/task/CalcZernikesTask.py
@@ -156,17 +156,17 @@ class CalcZernikesTask(pipeBase.PipelineTask):
             DonutStamp postage stamp image.
         """
 
-        if np.shape(donutStamp.blend_centroid_positions)[1] > 0:
-            blendOffsets = (
-                donutStamp.blend_centroid_positions - donutStamp.centroid_position
-            )
+        blendCentroids = donutStamp.blend_centroid_positions
+        # If there are blends the array will not have nans
+        if np.sum(np.isnan(blendCentroids)) == 0:
+            blendOffsets = blendCentroids - donutStamp.centroid_position
             blendOffsets = np.dot(blendOffsets, rotMatrix(eulerAngle))
             # Exchange X,Y since we transpose the image below
             blendOffsets = blendOffsets.T[::-1]
         else:
-            # If empty array then just pass this as the offset since
-            # CompensableImage understands empty lists mean no blend
-            blendOffsets = donutStamp.blend_centroid_positions
+            # If no blend then pass nan array.
+            # CompensableImage understands nans means no blend.
+            blendOffsets = blendCentroids.T
 
         return blendOffsets
 

--- a/python/lsst/ts/wep/task/CutOutDonutsBase.py
+++ b/python/lsst/ts/wep/task/CutOutDonutsBase.py
@@ -466,6 +466,7 @@ class CutOutDonutsBaseTask(pipeBase.PipelineTask):
             finalBlendYList.append(blendStrY)
 
             # Prepare blend centroid position information
+            blendExists = False
             if len(donutRow["blend_centroid_x"]) > 0:
                 blendCentroidPositions = np.array(
                     [
@@ -473,8 +474,9 @@ class CutOutDonutsBaseTask(pipeBase.PipelineTask):
                         donutRow["blend_centroid_y"] + yShift,
                     ]
                 ).T
+                blendExists = True
             else:
-                blendCentroidPositions = np.array([[], []])
+                blendCentroidPositions = np.array([["nan"], ["nan"]], dtype=float).T
 
             donutStamp = DonutStamp(
                 stamp_im=finalStamp,
@@ -499,7 +501,6 @@ class CutOutDonutsBaseTask(pipeBase.PipelineTask):
             donutStamp.stamp_im.setMask(donutStamp.mask_comp)
 
             # Create shifted mask from non-blended mask
-            blendExists = len(donutRow["blend_centroid_x"]) > 0
             if (self.multiplyMask is True) and blendExists:
                 donutStamp.comp_im.makeMask(
                     inst, self.opticalModel, boundaryT, maskScalingFactorLocal

--- a/python/lsst/ts/wep/task/DonutStamp.py
+++ b/python/lsst/ts/wep/task/DonutStamp.py
@@ -131,7 +131,7 @@ class DonutStamp(AbstractStamp):
                 dtype=float,
             ).T
         else:
-            blend_centroid_positions = np.array([[], []])
+            blend_centroid_positions = np.array([["nan"], ["nan"]], dtype=float).T
 
         return cls(
             stamp_im=stamp_im,

--- a/python/lsst/ts/wep/task/DonutStamps.py
+++ b/python/lsst/ts/wep/task/DonutStamps.py
@@ -107,8 +107,8 @@ class DonutStamps(StampsBase):
             blendStrX = ""
             blendStrY = ""
             if np.shape(centroid_array)[1] == 0:
-                finalBlendXList.append(None)
-                finalBlendYList.append(None)
+                finalBlendXList.append("nan")
+                finalBlendYList.append("nan")
                 continue
             for blend_cx, blend_cy in centroid_array:
                 blendStrX += f"{blend_cx:.2f},"

--- a/tests/task/test_calcZernikesTaskCwfs.py
+++ b/tests/task/test_calcZernikesTaskCwfs.py
@@ -122,7 +122,7 @@ class TestCalcZernikesTaskCwfs(lsst.utils.tests.TestCase):
         eulerAngle = 0
         blendOffsetsNone = self.task.calcBlendOffsets(donutStampExtra, eulerAngle)
         np.testing.assert_array_almost_equal(
-            blendOffsetsNone, donutStampExtra.blend_centroid_positions
+            blendOffsetsNone, np.array([["nan"], ["nan"]], dtype=float)
         )
         # Test with blend centroid present
         trueOffset = np.array([[10.0], [10.0]])

--- a/tests/task/test_donutStamp.py
+++ b/tests/task/test_donutStamp.py
@@ -148,9 +148,10 @@ class TestDonutStamp(unittest.TestCase):
             defocalDist = donutStamp.defocal_distance
             # Test default metadata distance of 1.5 mm
             self.assertEqual(defocalDist, 1.5)
-            # Test blend centroids arrays are empty
+            # Test blend centroids arrays are nans
             np.testing.assert_array_equal(
-                donutStamp.blend_centroid_positions, np.array([[], []])
+                donutStamp.blend_centroid_positions,
+                np.array([["nan"], ["nan"]], dtype=float).T,
             )
 
     def testGetCamera(self):

--- a/tests/task/test_donutStamps.py
+++ b/tests/task/test_donutStamps.py
@@ -56,14 +56,18 @@ class TestDonutStamps(lsst.utils.tests.TestCase):
         decs = np.arange(nStamps) + 5
         centX = np.arange(nStamps) + 20
         centY = np.arange(nStamps) + 25
-        blendCentX = np.array([f"{val}" for val in np.arange(30, 30 + nStamps)])
-        blendCentY = np.array([f"{val}" for val in np.arange(35, 35 + nStamps)])
+        blendCentX = [f"{val}" for val in np.arange(30, 30 + nStamps)]
+        blendCentY = [f"{val}" for val in np.arange(35, 35 + nStamps)]
         detectorNames = ["R22_S11"] * nStamps
         camNames = ["LSSTCam"] * nStamps
         dfcTypes = [DefocalType.Extra.value] * nStamps
         halfStampIdx = int(nStamps / 2)
         dfcTypes[:halfStampIdx] = [DefocalType.Intra.value] * halfStampIdx
         dfcDists = np.ones(nStamps) * 1.5
+
+        # Test mixture of donuts with blends and those without
+        blendCentX[-1] = "nan"
+        blendCentY[-1] = "nan"
 
         metadata = PropertyList()
         metadata["RA_DEG"] = ras
@@ -133,9 +137,11 @@ class TestDonutStamps(lsst.utils.tests.TestCase):
     def testGetBlendCentroids(self):
 
         xPos, yPos = self.donutStamps.getBlendCentroids()
-        for idx in range(self.nStamps):
+        for idx in range(self.nStamps - 1):
             self.assertEqual(xPos[idx], f"{idx + 30:.2f}")
             self.assertEqual(yPos[idx], f"{idx + 35:.2f}")
+        self.assertEqual(xPos[-1], "nan")
+        self.assertEqual(yPos[-1], "nan")
 
     def testGetDetectorNames(self):
 


### PR DESCRIPTION
Use nans instead of None so we can convert to float and use writeFits method in DonutStamps successfully and save in butler.

Update versionHistory.