### PR TITLE
Tickets/DM-37903: add transposeImages config to CalcZernikesTask

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-4.2.3:
+
+-------------
+4.2.3
+-------------
+
+* Add transposeImages as optional config to CalcZernikesTask.
+
 .. _lsst.ts.wep-4.2.2:
 
 -------------


### PR DESCRIPTION
Given the findings of https://jira.lsstcorp.org/browse/DM-37903, it is recommended not to transpose images for auxTel (and possibly other real-telescope images). This PR adds transposing images as an optional config. By default (eg. using phoSim images) the transpose is done as before, so that no tests need amendment. 