### PR TITLE
[tickets/DM-39590] Fix empty catalog output from donutSourceSelectorTask

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,15 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-6.3.5:
+
+-------------
+6.3.5
+-------------
+
+* Make sure output from empty catalogs match that expected from catalogs with sources in donutSourceSelectorTask.
+* Add tests for run method in donutSourceSelectorTask.
+
 .. _lsst.ts.wep-6.3.4:
 
 -------------

--- a/python/lsst/ts/wep/task/donutSourceSelectorTask.py
+++ b/python/lsst/ts/wep/task/donutSourceSelectorTask.py
@@ -195,7 +195,11 @@ class DonutSourceSelectorTask(pipeBase.Task):
 
         selected = np.zeros(len(sourceCat), dtype=bool)
         if len(selected) == 0:
-            return pipeBase.Struct(selected=selected)
+            return pipeBase.Struct(
+                selected=selected,
+                blendCentersX=None,
+                blendCentersY=None,
+            )
 
         fluxField = f"{filterName}_flux"
         flux = _getFieldFromCatalog(sourceCat, fluxField)


### PR DESCRIPTION
The output from empty catalogs was causing donutSourceSelectorTask to fail when running the task because it was not outputting a `Struct` with the same format as when there is a catalog with sources. The following changes were made to fix this:

* Make sure output from empty catalogs match that expected from catalogs with sources in donutSourceSelectorTask. 
* Add tests for run method.