### PR TITLE
Tickets/DM-40597

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-6.4.9:
+
+-------------
+6.4.9
+-------------
+
+* Replacing lookUpCalibrations function to use the one in lsst.fgcmcal.utilities
+
 .. _lsst.ts.wep-6.4.8:
 
 -------------

--- a/python/lsst/ts/wep/task/cutOutDonutsBase.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsBase.py
@@ -29,8 +29,8 @@ import lsst.afw.cameraGeom
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 import numpy as np
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 from lsst.daf.base import PropertyList
+from lsst.fgcmcal.utilities import lookupStaticCalibrations
 from lsst.pipe.base import connectionTypes
 from lsst.ts.wep.cwfs.donutTemplateFactory import DonutTemplateFactory
 from lsst.ts.wep.cwfs.instrument import Instrument
@@ -72,7 +72,7 @@ class CutOutDonutsBaseTaskConnections(
         doc="Input camera to construct complete exposures.",
         dimensions=["instrument"],
         isCalibration=True,
-        lookupFunction=lookupStaticCalibration,
+        lookupFunction=lookupStaticCalibrations,
     )
     donutStampsExtra = connectionTypes.Output(
         doc="Extra-focal Donut Postage Stamp Images",

--- a/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
+++ b/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
@@ -30,7 +30,7 @@ import lsst.pipe.base as pipeBase
 import lsst.pipe.base.connectionTypes as connectionTypes
 import numpy as np
 import pandas as pd
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
+from lsst.fgcmcal.utilities import lookupStaticCalibrations
 from lsst.ts.wep.cwfs.donutTemplateFactory import DonutTemplateFactory
 from lsst.ts.wep.task.donutQuickMeasurementTask import DonutQuickMeasurementTask
 from lsst.ts.wep.task.donutSourceSelectorTask import DonutSourceSelectorTask
@@ -75,7 +75,7 @@ class GenerateDonutDirectDetectTaskConnections(
         doc="Input camera to construct complete exposures.",
         dimensions=["instrument"],
         isCalibration=True,
-        lookupFunction=lookupStaticCalibration,
+        lookupFunction=lookupStaticCalibrations,
     )
 
 

--- a/ups/ts_wep.table
+++ b/ups/ts_wep.table
@@ -5,6 +5,7 @@
 setupRequired(sconsUtils)
 setupRequired(utils)
 setupRequired(obs_lsst)
+setupRequired(fgcmcal)
 setupRequired(afw)
 setupRequired(ctrl_mpexec)
 setupRequired(cp_pipe)


### PR DESCRIPTION
lsst.cp.pipe._lookupStaticCalibration was recently descoped (https://github.com/lsst/cp_pipe/commit/bc7839e51edc76e17a13a777b0f87cd91713059f). This ticket changes it to lsst.fgcmcal.utilities lookupStaticCalibrations function (https://github.com/lsst/fgcmcal/blob/023b260a0ee01728ff57feb24fac45a111fe17fb/python/lsst/fgcmcal/utilities.py#L857)