### PR TITLE
DM-40905: fix GenerateDonutFromRefitWcsTask

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-6.4.11:
+
+-------------
+6.4.11
+-------------
+
+* Fix GenerateDonutFromRefitWcsTask adding coord_raErr, coord_decErr fields.
+
 .. _lsst.ts.wep-6.4.10:
 
 -------------


### PR DESCRIPTION
Add `coord_raErr`, `coord_decErr` fields to a table passed to `AstrometryTask.run` to refit WCS from the direct detect donut catalog, to work with updates from `lsst_distrib` `w2020_38` https://lsst-dm.github.io/lsst_git_changelog/weekly/w_2023_38.html 