### PR TITLE
Tickets/DM-41022: fix generateDonutDirectDetect

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -5,6 +5,14 @@
 ##################
 Version History
 ##################
+.. _lsst.ts.wep-7.0.1:
+
+-------------
+7.0.1
+-------------
+
+* Fix generateDonutDirectDetect when doDonutSelection is not run.
+
 
 .. _lsst.ts.wep-7.0.0:
 

--- a/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
+++ b/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
@@ -285,6 +285,10 @@ class GenerateDonutDirectDetectTask(pipeBase.PipelineTask):
             donutCatSelected["blend_centroid_x"] = donutSelection.blendCentersX
             donutCatSelected["blend_centroid_y"] = donutSelection.blendCentersY
         else:
+            # if donut selector was not run,
+            # set the required columns to be empty
+            donutDf["blend_centroid_x"] = ""
+            donutDf["blend_centroid_y"] = ""
             donutCatSelected = donutDf
 
         donutCatSelected.rename(


### PR DESCRIPTION
Adding an empty `blend_centroid_x`, `blend_centroid_y` columns to a donut catalog in case `donutSelector` was not run.