### PR TITLE
Tickets/DM-43293: fix latiss tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,6 +17,7 @@ jobs:
 
       - name: Install
         run: |
+          $CONDA/bin/conda install python=3.11
           $CONDA/bin/conda install -c lsstts ts-pre-commit-config -y
           $CONDA/bin/conda install -c conda-forge pre-commit -y
           $CONDA/bin/generate_pre_commit_conf --skip-pre-commit-install

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See the docs: <https://ts-wep.lsst.io/>
 - lsst_distrib (tag: `w_latest`)
 - [git-lfs](https://git-lfs.com/)
 - [galsim](https://github.com/GalSim-developers/GalSim) (version >= 2.3; should be available from science pipelines v2.0.0 and up)
+- [batoid](https://jmeyers314.github.io/batoid/overview.html) (version >= 0.6.0)
 - [black](https://github.com/psf/black) (optional)
 - [documenteer](https://github.com/lsst-sqre/documenteer) (optional)
 - [plantuml](http://plantuml.com) (optional)

--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,18 @@
 Version History
 ##################
 
+-------------
+9.1.1
+-------------
+
+.. _lsst.ts.wep-9.1.1:
+
+* Fix latiss tests by using getpass, and updating Zk values
+
+-------------
+9.1.0
+-------------
+
 .. _lsst.ts.wep-9.1.0:
 
 * Added ``jmin`` arguments to Zernike utility functions.

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,3 +1,12 @@
 # -*- python -*-
-from lsst.sconsUtils import scripts
+from lsst.sconsUtils import scripts, env
+import os
+
+pgpassfile = os.getenv("PGPASSFILE")
+pguser = os.getenv("PGUSER")
+if pgpassfile:
+    env["ENV"]["PGPASSFILE"] = pgpassfile
+if pguser:
+    env["ENV"]["PGUSER"] = pguser
+
 scripts.BasicSConscript.tests(pyList=[])

--- a/tests/task/test_calcZernikesTaskLatiss.py
+++ b/tests/task/test_calcZernikesTaskLatiss.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import getpass
 import os
 import tempfile
 
@@ -44,6 +45,10 @@ from lsst.ts.wep.utils import (
     os.path.exists("/sdf/data/rubin/repo/main") is False,
     reason="requires access to data in /repo/main",
 )
+@pytest.mark.skipif(
+    not os.getenv("PGPASSFILE"),
+    reason="requires access to butler db",
+)
 class TestCalcZernikesTaskLatiss(lsst.utils.tests.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -59,7 +64,7 @@ class TestCalcZernikesTaskLatiss(lsst.utils.tests.TestCase):
         # Create a temporary test directory
         # under /sdf/data/rubin/repo/main/u/$USER
         # to ensure write access is granted
-        user = os.getlogin()
+        user = getpass.getuser()
         tempDir = os.path.join(cls.repoDir, "u", user)
         cls.testDir = tempfile.TemporaryDirectory(dir=tempDir)
         testDirName = os.path.split(cls.testDir.name)[1]  # temp dir name
@@ -147,28 +152,27 @@ class TestCalcZernikesTaskLatiss(lsst.utils.tests.TestCase):
         # Previous Zernikes for regression test
         zk = np.array(
             [
-                -0.00283742,
-                0.12024323,
-                -0.05781533,
-                -0.00683463,
-                -0.01198631,
-                0.03911933,
-                -0.07739852,
-                -0.0307383,
-                0.0114996,
-                -0.00157382,
-                -0.00154171,
-                -0.00857287,
-                0.00426482,
-                -0.00160444,
-                0.01318693,
-                -0.00538555,
-                -0.02333674,
-                -0.02252251,
-                0.00943855,
+                0.06301116,
+                0.16224293,
+                -0.03171561,
+                -0.01889007,
+                0.00448589,
+                0.03581878,
+                -0.05704621,
+                -0.02594513,
+                0.01350136,
+                -0.00455589,
+                -0.01713792,
+                0.00590172,
+                0.00505236,
+                0.0015623,
+                0.01403694,
+                -0.00709998,
+                -0.03391995,
+                -0.02250289,
+                0.0147995,
             ]
         )
-
         self.assertTrue(np.allclose(zk, zernCoeff.outputZernikesRaw[0]))
 
     def testGetCombinedZernikes(self):

--- a/tests/task/test_cutOutDonutsLatissTask.py
+++ b/tests/task/test_cutOutDonutsLatissTask.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import getpass
 import os
 import tempfile
 
@@ -41,7 +42,11 @@ from lsst.ts.wep.utils import (
 
 @pytest.mark.skipif(
     os.path.exists("/sdf/data/rubin/repo/main") is False,
-    reason="requires access to data in /repo/main",
+    reason="requires access to data in /repo/main database",
+)
+@pytest.mark.skipif(
+    not os.getenv("PGPASSFILE"),
+    reason="requires access to butler db",
 )
 class TestCutOutDonutsLatissTask(lsst.utils.tests.TestCase):
     @classmethod
@@ -59,7 +64,7 @@ class TestCutOutDonutsLatissTask(lsst.utils.tests.TestCase):
         # Create a temporary test directory
         # under /sdf/data/rubin/repo/main/u/$USER
         # to ensure write access is granted
-        user = os.getlogin()
+        user = getpass.getuser()
         tempDir = os.path.join(cls.repoDir, "u", user)
         cls.testDir = tempfile.TemporaryDirectory(dir=tempDir)
         testDirName = os.path.split(cls.testDir.name)[1]  # temp dir name


### PR DESCRIPTION
Fixing latiss tests by switching from `os.getlogin` to `getpass` (the former didn't work on RSP), and updating Zk values. README is also updated to point out that `batoid` > 0.6.0 is required to work with `batoidOffsetValue` 