### PR TITLE
DM-43340: Add exposure pairing for full array mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ config.log
 
 # Built by sconsUtils
 version.py
-bin/
+/bin/
 
 # Pytest
 tests/.tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
                         git lfs fetch --all || echo git lfs fetch FAILED
                         git lfs checkout || echo git lfs checkout FAILED
                         setup -k -r .
-                        scons python
+                        scons lib python shebang
                     """
                 }
             }

--- a/bin.src/generatePairTable.py
+++ b/bin.src/generatePairTable.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+# This file is part of ts_wep.
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from lsst.ts.wep.bin.generatePairTable import main
+
+if __name__ == "__main__":
+    main()

--- a/bin.src/ingestPairTable.py
+++ b/bin.src/ingestPairTable.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+# This file is part of ts_wep.
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from lsst.ts.wep.bin.ingestPairTable import main
+
+if __name__ == "__main__":
+    main()

--- a/doc/developer-guide/developer-guide.rst
+++ b/doc/developer-guide/developer-guide.rst
@@ -148,6 +148,8 @@ This module has the tasks to run WEP as a pipeline with Gen 3 LSST DM middleware
 * **GenerateDonutFromRefitWcsTaskConnections**: Connections setup for GenerateDonutFromRefitWcsTask.
 * **GenerateDonutFromRefitWcsTaskConfig**: Configuration setup for GenerateDonutFromRefitWcsTask.
 * **GenerateDonutCatalogUtils**: Common utility functions for the GenerateDonutCatalog...Tasks.
+* **ExposurePairer**: Subtask to pair intra- and extra-focal exposures heuristically.
+* **TablePairer**: Subtask to pair intra- and extra-focal exposures manually from a table.  Use generatePairTable.py script as a useful starting point.
 
 .. _WEP_modules_wep_utils:
 
@@ -160,7 +162,7 @@ This module contains utility functions that are used elsewhere in WEP.
 * **ioUtils**: Functions for reading and writing files.
 * **maskUtils**: Functions for generating a mask model for an instrument.
 * **taskUtils**: Functions for running command line tasks from a python script.
-* **zernikeUtils**: Functions for evaluating and fitting Zernike polynomials. 
+* **zernikeUtils**: Functions for evaluating and fitting Zernike polynomials.
 * **plotUtils**: Functions for plotting results.
 * **miscUtils**: Miscellaneous utility functions.
 

--- a/doc/uml/taskClass.uml
+++ b/doc/uml/taskClass.uml
@@ -29,6 +29,7 @@ CutOutDonutsScienceSensorTaskConfig *-- CutOutDonutsBaseTaskConnections
 CutOutDonutsScienceSensorTask *-- CutOutDonutsScienceSensorTaskConfig
 CutOutDonutsBaseTaskConnections <|-- CutOutDonutsScienceSensorTaskConnections
 CutOutDonutsScienceSensorTaskConfig *-- CutOutDonutsScienceSensorTaskConnections
+CutOutDonutsScienceSensorTaskConfig *-- ExposurePairer
 CutOutDonutsScienceSensorTask ..> DonutStamps
 CutOutDonutsBaseTaskConfig *-- CutOutDonutsBaseTaskConnections
 CutOutDonutsBaseTask *-- CutOutDonutsBaseTaskConfig
@@ -42,4 +43,6 @@ GenerateDonutFromRefitWcsTaskConfig *-- GenerateDonutFromRefitWcsTaskConnections
 GenerateDonutCatalogWcsTaskConfig <|-- GenerateDonutFromRefitWcsTaskConfig
 GenerateDonutFromRefitWcsTask *-- GenerateDonutFromRefitWcsTaskConfig
 GenerateDonutCatalogWcsTask <|-- GenerateDonutFromRefitWcsTask
+ExposurePairer *-- ExposurePairerConfig
+TablePairer *-- TablePairerConfig
 @enduml

--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,13 +6,20 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-9.5.0:
+-------------
+9.5.0
+-------------
+
+* Add exposure pairing for full array mode.
+
 .. _lsst.ts.wep-9.4.0:
 -------------
 9.4.0
 -------------
 
 * Added the Danish wavefront estimation algorithm.
-  
+
 .. _lsst.ts.wep-9.3.1:
 
 -------------

--- a/python/lsst/ts/wep/bin/generatePairTable.py
+++ b/python/lsst/ts/wep/bin/generatePairTable.py
@@ -1,0 +1,158 @@
+# This file is part of ts_wep.
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from argparse import ArgumentParser
+
+from lsst.daf.butler import Butler
+from lsst.ts.wep.task.pairTask import ExposurePairer, ExposurePairerConfig
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "-b",
+        "--butler-config",
+        help="Location of the butler/registry config file.",
+        required=True,
+        metavar="TEXT",
+    )
+    parser.add_argument(
+        "-c", "--collection", help="Collection name.", required=True, metavar="NAME"
+    )
+    parser.add_argument(
+        "-o",
+        type=str,
+        help="Output filename.",
+        required=True,
+        metavar="FILENAME",
+    )
+    parser.add_argument(
+        "--instrument",
+        type=str,
+        help="Name of the instrument.",
+        required=True,
+        metavar="INST",
+    )
+    parser.add_argument(
+        "-d",
+        "--data-query",
+        type=str,
+        help="User data selection expression.",
+        required=True,
+        metavar="QUERY",
+    )
+    parser.add_argument(
+        "--timeThreshold",
+        type=float,
+        help="Maximum time difference between paired intra- and extra-focal exposures (s)",
+        default=300.0,
+        metavar="SEC",
+    )
+    parser.add_argument(
+        "--pointingThreshold",
+        type=float,
+        help="Maximum pointing difference between paired intra- and extra-focal exposures (arcsec)",
+        default=60.0,
+        metavar="ARCSEC",
+    )
+    parser.add_argument(
+        "--rotationThreshold",
+        type=float,
+        help="Maximum rotator angle difference between paired intra- and extra-focal exposures (deg)",
+        default=1.0,
+        metavar="DEG",
+    )
+    parser.add_argument(
+        "--overrideSeparation",
+        type=float,
+        help="Expected intra-focal to focal separation (mm)",
+        default=None,
+        metavar="MM",
+    )
+    parser.add_argument(
+        "--groupingThreshold",
+        type=float,
+        help="Threshold for assigning visit to intra/extra/focal group as a fraction of the expected"
+        " intra-focal to focal separation.",
+        default=0.1,
+        metavar="FRAC",
+    )
+    parser.add_argument(
+        "--forceUniquePairs",
+        action="store_true",
+        help="If True, force each extra exposure to be paired with a unique intra exposure.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output.",
+    )
+
+    args = parser.parse_args()
+
+    butler = Butler(args.butler_config, collections=args.collection)
+
+    doOverrideSeparation = False
+    overrideSeparation = 1.5
+    if args.overrideSeparation is not None:
+        overrideSeparation = args.overrideSeparation
+        doOverrideSeparation = True
+
+    config = ExposurePairerConfig(
+        timeThreshold=args.timeThreshold,
+        pointingThreshold=args.pointingThreshold,
+        rotationThreshold=args.rotationThreshold,
+        doOverrideSeparation=doOverrideSeparation,
+        overrideSeparation=overrideSeparation,
+        groupingThreshold=args.groupingThreshold,
+        forceUniquePairs=args.forceUniquePairs,
+    )
+    pairer = ExposurePairer(config=config)
+
+    visitInfos = {
+        v.dataId["exposure"]: butler.get("raw.visitInfo", dataId=v.dataId)
+        for v in butler.registry.queryDatasets("raw", where=args.data_query)
+    }
+
+    tables = pairer.makeTables(visitInfos)
+
+    print()
+    print("Found pairs")
+    tables["pairTable"].pprint_all()
+    print()
+    print("Writing pairs to file: ", args.o)
+    tables["pairTable"].write(args.o, format="ascii.ecsv", overwrite=True)
+
+    if args.verbose:
+        if len(tables["unusedExtraTable"]) > 0:
+            print()
+            print("Unused extra exposures")
+            tables["unusedExtraTable"].pprint_all()
+        if len(tables["unusedIntraTable"]) > 0:
+            print()
+            print("Unused intra exposures")
+            tables["unusedIntraTable"].pprint_all()
+        if len(tables["focalTable"]) > 0:
+            print()
+            print("Focal exposures")
+            tables["focalTable"].pprint_all()

--- a/python/lsst/ts/wep/bin/ingestPairTable.py
+++ b/python/lsst/ts/wep/bin/ingestPairTable.py
@@ -1,0 +1,97 @@
+# This file is part of ts_wep.
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import logging
+import time
+from argparse import ArgumentParser
+
+from astropy.table import Table
+from lsst.daf.butler import Butler, CollectionType, DatasetType, DimensionUniverse
+
+
+def main():
+    tz = time.strftime("%z")
+    logging.basicConfig(
+        format="%(levelname)s %(asctime)s.%(msecs)03d" + tz + " - %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.DEBUG)
+
+    parser = ArgumentParser()
+    parser.add_argument(
+        "-b",
+        "--butler-config",
+        help="Location of the butler/registry config file.",
+        required=True,
+        metavar="TEXT",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-collection",
+        type=str,
+        help="Name of the output collection to ingest the injection catalog into.",
+        required=True,
+        metavar="COLL",
+    )
+    parser.add_argument(
+        "--instrument",
+        type=str,
+        help="Name of the instrument.",
+        required=True,
+        metavar="INST",
+    )
+    parser.add_argument(
+        "pairs",
+        type=str,
+        help="Path to the pair table to ingest.",
+    )
+    args = parser.parse_args()
+
+    logger.info(f"Reading pair table from {args.pairs}")
+    table = Table.read(args.pairs)
+
+    logger.info(f"Writing pair table to butler collection {args.output_collection}")
+    butler = Butler(args.butler_config, writeable=True)
+
+    # Register if needed
+    logger.info("Registering donutVisitPairTable dataset type")
+    donutVisitPairTableDatasetType = DatasetType(
+        "donutVisitPairTable",
+        tuple(["instrument"]),
+        "AstropyTable",
+        universe=DimensionUniverse(),
+    )
+    butler.registry.registerDatasetType(donutVisitPairTableDatasetType)
+    logger.info("Registering donutVisitPairTable collection")
+    butler.registry.registerCollection(
+        name=args.output_collection, type=CollectionType.RUN
+    )
+
+    logger.info("Ingesting pair table")
+    butler.put(
+        table,
+        donutVisitPairTableDatasetType,
+        dict(instrument=args.instrument),
+        run=args.output_collection,
+    )
+    logger.info("Done")

--- a/python/lsst/ts/wep/task/__init__.py
+++ b/python/lsst/ts/wep/task/__init__.py
@@ -17,4 +17,5 @@ from .generateDonutCatalogUtils import *
 from .generateDonutCatalogWcsTask import *
 from .generateDonutDirectDetectTask import *
 from .generateDonutFromRefitWcsTask import *
+from .pairTask import *
 from .refCatalogInterface import *

--- a/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
@@ -29,9 +29,10 @@ import typing
 
 import lsst.afw.cameraGeom
 import lsst.afw.image as afwImage
+import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
+import lsst.pipe.base.connectionTypes as ct
 import pandas as pd
-from lsst.pipe.base import connectionTypes
 from lsst.ts.wep.task.cutOutDonutsBase import (
     CutOutDonutsBaseTask,
     CutOutDonutsBaseTaskConfig,
@@ -41,15 +42,17 @@ from lsst.ts.wep.task.donutStamps import DonutStamps
 from lsst.ts.wep.utils import DefocalType
 from lsst.utils.timer import timeMethod
 
+from .pairTask import ExposurePairer
+
 
 class CutOutDonutsScienceSensorTaskConnections(
     CutOutDonutsBaseTaskConnections, dimensions=("detector", "instrument")
 ):
-    exposures = connectionTypes.Input(
-        doc="Input exposure to make measurements on",
+    visitInfos = ct.Input(
+        doc="Exposure VisitInfos",
         dimensions=("exposure", "detector", "instrument"),
-        storageClass="Exposure",
-        name="postISRCCD",
+        storageClass="VisitInfo",
+        name="postISRCCD.visitInfo",
         multiple=True,
     )
 
@@ -58,7 +61,10 @@ class CutOutDonutsScienceSensorTaskConfig(
     CutOutDonutsBaseTaskConfig,
     pipelineConnections=CutOutDonutsScienceSensorTaskConnections,
 ):
-    pass
+    pairer = pexConfig.ConfigurableField(
+        target=ExposurePairer,
+        doc="Task to pair up intra- and extra-focal exposures",
+    )
 
 
 class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
@@ -68,6 +74,10 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
 
     ConfigClass = CutOutDonutsScienceSensorTaskConfig
     _DefaultName = "CutOutDonutsScienceSensorTask"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.makeSubtask("pairer")
 
     def runQuantum(
         self,
@@ -86,20 +96,38 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
         so we put this in the dataId associated with the
         extra-focal detector.
         """
-
-        exposures = butlerQC.get(inputRefs.exposures)
-        focusZVals = [exp.visitInfo.focusZ for exp in exposures]
         camera = butlerQC.get(inputRefs.camera)
-        extraIdx, intraIdx = self.assignExtraIntraIdx(
-            focusZVals[0], focusZVals[1], camera.getName()
-        )
 
-        donutCats = butlerQC.get(inputRefs.donutCatalog)
+        visitInfoDict = {
+            v.dataId["exposure"]: butlerQC.get(v) for v in inputRefs.visitInfos
+        }
+        exposureHandleDict = {v.dataId["exposure"]: v for v in inputRefs.exposures}
+        donutCatalogHandleDict = {v.dataId["visit"]: v for v in inputRefs.donutCatalog}
+        donutStampsIntraHandleDict = {
+            v.dataId["visit"]: v for v in outputRefs.donutStampsIntra
+        }
+        donutStampsExtraHandleDict = {
+            v.dataId["visit"]: v for v in outputRefs.donutStampsExtra
+        }
 
-        outputs = self.run(exposures, donutCats, camera)
-
-        butlerQC.put(outputs.donutStampsExtra, outputRefs.donutStampsExtra[extraIdx])
-        butlerQC.put(outputs.donutStampsIntra, outputRefs.donutStampsIntra[extraIdx])
+        pairs = self.pairer.run(visitInfoDict)
+        for pair in pairs:
+            exposures = butlerQC.get(
+                [exposureHandleDict[k] for k in [pair.intra, pair.extra]]
+            )
+            donutCats = butlerQC.get(
+                [donutCatalogHandleDict[k] for k in [pair.intra, pair.extra]]
+            )
+            outputs = self.run(exposures, donutCats, camera)
+            butlerQC.put(
+                outputs.donutStampsExtra, donutStampsExtraHandleDict[pair.extra]
+            )
+            butlerQC.put(
+                outputs.donutStampsIntra,
+                donutStampsIntraHandleDict[
+                    pair.extra
+                ],  # Intentionally use extra id for intra stamps here
+            )
 
     def assignExtraIntraIdx(self, focusZVal0, focusZVal1, cameraName):
         """

--- a/python/lsst/ts/wep/task/pairTask.py
+++ b/python/lsst/ts/wep/task/pairTask.py
@@ -74,6 +74,11 @@ class ExposurePairerConfig(pexConfig.Config):
         default=0.1,
     )
 
+    forceUniquePairs = pexConfig.Field[bool](
+        doc="If True, force each extra exposure to be paired with a unique intra exposure.",
+        default=True,
+    )
+
 
 class ExposurePairer(pipeBase.Task):
     ConfigClass = ExposurePairerConfig
@@ -168,6 +173,12 @@ class ExposurePairer(pipeBase.Task):
                 out.append(
                     IntraExtraIdxPair(nearbyTable[nearest]["exposure"], row["exposure"])
                 )
+                if self.config.forceUniquePairs:
+                    idx = np.where(
+                        intraTable["exposure"] == nearbyTable[nearest]["exposure"]
+                    )[0]
+                    intraTable.remove_rows(idx)
+
         return out
 
 

--- a/python/lsst/ts/wep/task/pairTask.py
+++ b/python/lsst/ts/wep/task/pairTask.py
@@ -1,0 +1,166 @@
+# This file is part of ts_wep.
+#
+# Developed for the LSST Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = [
+    "ExposurePairerConfig",
+    "ExposurePairer",
+]
+
+import typing
+
+import lsst.afw.image as afwImage
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.table import Table
+from lsst.geom import radians
+
+
+class IntraExtraIdxPair(typing.NamedTuple):
+    intra: int
+    extra: int
+
+
+class ExposurePairerConfig(pexConfig.Config):
+    timeThreshold = pexConfig.Field[float](
+        doc="Maximum time difference between paired intra- and extra-focal exposures (s)",
+        default=300,
+    )
+
+    pointingThreshold = pexConfig.Field[float](
+        doc="Maximum pointing difference between paired intra- and extra-focal exposures (arcsec)",
+        default=60,
+    )
+
+    rotationThreshold = pexConfig.Field[float](
+        doc="Maximum rotator angle difference between paired intra- and extra-focal exposures (deg)",
+        default=1.0,
+    )
+
+    doOverrideSeparation = pexConfig.Field[bool](
+        doc="Whether to override expected intra-focal to focal separation",
+        default=False,
+    )
+
+    overrideSeparation = pexConfig.Field[float](
+        doc="Expected intra-focal to focal separation (mm)",
+        default=1.5,
+    )
+
+    groupingThreshold = pexConfig.Field[float](
+        doc="Threshold for assigning visit to intra/extra/focal group as a fraction of the expected "
+        "intra-focal to focal separation.",
+        default=0.1,
+    )
+
+
+class ExposurePairer(pipeBase.Task):
+    ConfigClass = ExposurePairerConfig
+    _DefaultName = "exposurePairer"
+
+    def run(
+        self, visitInfos: typing.Dict[int, afwImage.VisitInfo]
+    ) -> typing.List[IntraExtraIdxPair]:
+        """
+        Pair up the intra- and extra-focal exposures.
+        """
+        if self.config.doOverrideSeparation:
+            separation = self.config.overrideSeparation
+        else:
+            instrument = next(iter(visitInfos.values())).instrumentLabel
+            match instrument:
+                case "LSSTCam" | "LSSTComCam" | "LSSTComCamSim":
+                    separation = 1.5
+                case "LATISS":
+                    separation = 0.8
+
+        # Partition intra/extra/focal groups by finding a common offset that
+        # maximizes the number of assigned visits.
+        # If we're handed a pair of visitInfos with a focusZ difference
+        # of ~1.5 mm, then we can't generally decide if that's an
+        # intra/focal pair or a focal/extra pair.  Since the AOS pipeline
+        # is keyed on extrafocal dataIds, we'll assume we're always handed
+        # an extrafocal visitInfo in this case.
+
+        table = Table(
+            names=["exposure", "ra", "dec", "mjd", "focusZ", "rtp"],
+            dtype=[int, float, float, float, float, float],
+        )
+        for exposure, visitInfo in visitInfos.items():
+            radec = visitInfo.boresightRaDec
+            ra = radec.getLongitude().asRadians()
+            dec = radec.getLatitude().asRadians()
+            mjd = visitInfo.date.toAstropy().mjd
+            rtp = (
+                visitInfo.boresightParAngle
+                - visitInfo.boresightRotAngle
+                - (np.pi / 2 * radians)
+            ).asRadians()
+            focusZ = visitInfo.focusZ
+            table.add_row([exposure, ra, dec, mjd, focusZ, rtp])
+        table["radec"] = SkyCoord(table["ra"], table["dec"], unit="radian")
+        thresh = self.config.groupingThreshold * separation
+
+        best_n_inliers = 0
+        best_offset = None
+        for offset in np.unique(table["focusZ"]):
+            dz = table["focusZ"] - offset
+            n_extra = np.sum(np.abs(dz) < thresh)
+            n_focal = np.sum(np.abs(dz + separation) < thresh)
+            n_intra = np.sum(np.abs(dz + 2 * separation) < thresh)
+            if n_extra + n_focal + n_intra > best_n_inliers:
+                best_n_inliers = n_extra + n_focal + n_intra
+                best_offset = offset
+
+        extraTable = table[np.abs(table["focusZ"] - best_offset) < thresh]
+        # focalTable = table[
+        #     np.abs(table["focusZ"] - best_offset + separation) < thresh
+        # ]
+        intraTable = table[
+            np.abs(table["focusZ"] - best_offset + 2 * separation) < thresh
+        ]
+
+        # For each extra focal exposure, find the best intra focal exposure.
+        # Note that it's possible that the same intra exposure is paired with
+        # multiple extra exposures.
+        out = []
+        for row in extraTable:
+            nearby = (
+                np.abs(intraTable["mjd"] - row["mjd"]) * 86400
+                < self.config.timeThreshold
+            )
+            nearby &= (
+                np.abs(intraTable["rtp"] - row["rtp"]) * 3600
+                < self.config.rotationThreshold
+            )
+            nearby &= (
+                row["radec"].separation(intraTable["radec"]).deg
+                < self.config.pointingThreshold
+            )
+            if np.any(nearby):
+                nearbyTable = intraTable[nearby]
+                # Pick the nearest remaining point in radec
+                nearest = np.argmin(row["radec"].separation(nearbyTable["radec"]).deg)
+                out.append(
+                    IntraExtraIdxPair(nearbyTable[nearest]["exposure"], row["exposure"])
+                )
+        return out

--- a/tests/task/test_cutOutDonutsScienceSensorTask.py
+++ b/tests/task/test_cutOutDonutsScienceSensorTask.py
@@ -73,7 +73,7 @@ class TestCutOutDonutsScienceSensorTask(lsst.utils.tests.TestCase):
         pipeCmd = writePipetaskCmd(
             cls.repoDir, cls.runName, instrument, collections, pipelineYaml=pipelineYaml
         )
-        pipeCmd += " -d 'exposure IN (4021123106001, 4021123106002)'"
+        pipeCmd += " -d 'exposure IN (4021123106001..4021123106009)'"
         runProgram(pipeCmd)
 
     def setUp(self):

--- a/tests/testData/pairTable.ecsv
+++ b/tests/testData/pairTable.ecsv
@@ -1,0 +1,8 @@
+# %ECSV 1.0
+# ---
+# datatype:
+# - {name: intra, datatype: int64}
+# - {name: extra, datatype: int64}
+# schema: astropy-2.0
+intra extra
+4021123106002 4021123106001

--- a/tests/testData/pipelineConfigs/testCutoutsFamPipelineTablePairer.yaml
+++ b/tests/testData/pipelineConfigs/testCutoutsFamPipelineTablePairer.yaml
@@ -1,0 +1,13 @@
+# This yaml file is used to define the tasks and configuration of
+# a Gen 3 pipeline used for testing in ts_wep.
+description: wep pipeline snippet, to rerun cutouts after making catalogs but using the table pairer
+instrument: lsst.obs.lsst.LsstCam
+tasks:
+  cutOutDonutsScienceSensorTask:
+    class: lsst.ts.wep.task.cutOutDonutsScienceSensorTask.CutOutDonutsScienceSensorTask
+    config:
+      python: |
+        from lsst.ts.wep.task.pairTask import TablePairer
+        config.pairer.retarget(TablePairer)
+      donutStampSize: 160
+      initialCutoutPadding: 40

--- a/ups/ts_wep.table
+++ b/ups/ts_wep.table
@@ -13,3 +13,4 @@ setupRequired(cp_pipe)
 # The following is boilerplate for all packages.
 # See https://dmtn-001.lsst.io for details on LSST_LIBRARY_PATH.
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
+envPrepend(PATH, ${PRODUCT_DIR}/bin)


### PR DESCRIPTION
PR adds two new subtasks:
  `ExposurePairer` : automatically pairs intra/extra exposures based on focusz and proximity in time/space/rotation.
  `TablePairer` : pairs intra/extra exposures based on a pre-ingested table of exposure IDs.

Also included are scripts to ingest above table, and modifications to CutoutDonutsScienceSensorTask to use the pairers.

