### PR TITLE
Fix blend centroid coordinates in donut stamp generation.

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-9.5.4:
+
+-------------
+9.5.4
+-------------
+
+* Fix blend centroid coordinates in donut stamp generation.
+
 .. _lsst.ts.wep-9.5.3:
 
 -------------

--- a/python/lsst/ts/wep/task/donutStamp.py
+++ b/python/lsst/ts/wep/task/donutStamp.py
@@ -264,13 +264,14 @@ class DonutStamp(AbstractStamp):
             # Get the offsets in the original pixel coordinates
             blendOffsets = self.blend_centroid_positions - self.centroid_position
 
-            # Rotate the coordinates to match the science sensors
-            rotMat = np.array([[0, -1], [1, 0]])
-            rotMat = np.linalg.matrix_power(rotMat, nRot)
+            # Rotate the coordinates (by -90 each time)
+            # to match the science sensors
+            rotMat = np.array([[0, 1], [-1, 0]])
+            if self.defocal_type == "extra":
+                rotMat = np.linalg.matrix_power(rotMat, nRot + 2)
+            else:
+                rotMat = np.linalg.matrix_power(rotMat, nRot)
             blendOffsets = np.transpose(rotMat @ blendOffsets.T)
-
-            # Transpose the coordinates (DVCS -> CCS)
-            blendOffsets = blendOffsets[:, ::-1]
 
         else:
             blendOffsets = None


### PR DESCRIPTION
Two fixes:
1. Fix donut stamp tests so that the order of operations matches that of the donutStamp code. Now the euler angle is the same in the test as in the code and not off by a negative sign.
2. Fix rotation in blend coordinates and in tests.
