### PR TITLE
Update default maxFieldDist

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-9.5.7:
+
+-------------
+9.5.7
+-------------
+
+* Update default maxFieldDist in donutSourceSelectorTask.py after analysis in DM-42067 (see ts_analysis_notebooks/aos/vignetting).
+
 .. _lsst.ts.wep-9.5.6:
 
 -------------

--- a/python/lsst/ts/wep/task/donutSourceSelectorTask.py
+++ b/python/lsst/ts/wep/task/donutSourceSelectorTask.py
@@ -61,7 +61,7 @@ class DonutSourceSelectorTaskConfig(pexConfig.Config):
     # in ts_analysis_notebooks/aos/vignetting.
     maxFieldDist = pexConfig.Field(
         dtype=float,
-        default=1.813,
+        default=1.808,
         doc="Maximum distance from center of focal plane (in degrees).",
     )
     unblendedSeparation = pexConfig.Field(


### PR DESCRIPTION
Update `maxFieldDist` after analysis in DM-42067 notebook at `ts_analysis_notebooks/aos/vignetting`.