### PR TITLE
Tickets/DM-45279: add visit to donutStamps metadata

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-10.4.1:
+
+-------------
+10.4.1
+-------------
+
+* Add visit to donutStamps metadata.
+
 .. _lsst.ts.wep-10.4.0:
 
 -------------
@@ -22,7 +30,7 @@ Version History
 10.3.0
 -------------
 
-* Added single-side-of-focus mode to the TIE
+* Added single-side-of-focus mode to the TIE.
 
 .. _lsst.ts.wep-10.2.0:
 

--- a/python/lsst/ts/wep/task/cutOutDonutsBase.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsBase.py
@@ -302,6 +302,7 @@ class CutOutDonutsBaseTask(pipeBase.PipelineTask):
         detector = exposure.getDetector()
         detectorName = detector.getName()
         bandLabel = exposure.filter.bandLabel
+        visitId = exposure.getInfo().getVisitInfo().id
 
         # Run background subtraction
         self.subtractBackground.run(exposure=exposure).background
@@ -465,6 +466,7 @@ class CutOutDonutsBaseTask(pipeBase.PipelineTask):
         stampsMetadata["DEC_DEG"] = np.degrees(donutCatalog["coord_dec"].values)
         stampsMetadata["DET_NAME"] = np.array([detectorName] * catalogLength, dtype=str)
         stampsMetadata["CAM_NAME"] = np.array([cameraName] * catalogLength, dtype=str)
+        stampsMetadata["VISIT"] = np.array([visitId] * catalogLength, dtype=int)
         stampsMetadata["DFC_TYPE"] = np.array(
             [defocalType.value] * catalogLength, dtype=str
         )

--- a/tests/task/test_cutOutDonutsBase.py
+++ b/tests/task/test_cutOutDonutsBase.py
@@ -345,3 +345,27 @@ class TestCutOutDonutsBase(lsst.utils.tests.TestCase):
                     rtol=0.0,
                     atol=10e-6,  # 10 microarcsecond accurate over stamp region
                 )
+
+        # Check that all expected metadata is present
+        metadata = list(donutStamps.metadata)
+        expectedMetadata = [
+            "RA_DEG",
+            "DEC_DEG",
+            "DET_NAME",
+            "CAM_NAME",
+            "VISIT",
+            "DFC_TYPE",
+            "DFC_DIST",
+            "CENT_X",
+            "CENT_Y",
+            "BLEND_CX",
+            "BLEND_CY",
+            "X0",
+            "Y0",
+        ]
+        self.assertCountEqual(metadata, expectedMetadata)
+
+        # test that the visit is properly stored
+        self.assertEqual(
+            self.dataIdExtra["visit"], donutStamps.metadata.getArray("VISIT")[0]
+        )


### PR DESCRIPTION
To help with plotAOSTask, this allows to find out what was the exposure (visit) used to cut out donuts from, regardless of which visit they are stored with (as currently both `donutStampsExtra` and `donutStampsIntra` get saved with extra-focal `visit`, this allows to retrieve that at a later stage if we want to pass `donutStampsIntra` with the intra-focal visit). 