### PR TITLE
DM-46393: Optionally bin donut stamps before estimating wavefront

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-11.3.0:
+
+-------------
+11.3.0
+-------------
+
+* Add option to bin donut stamps before estimating the wavefront.
+
 .. _lsst.ts.wep-11.2.0:
 
 -------------

--- a/python/lsst/ts/wep/instrument.py
+++ b/python/lsst/ts/wep/instrument.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 __all__ = ["Instrument"]
 
 from functools import lru_cache
@@ -161,6 +163,29 @@ class Instrument:
 
         # Check the config
         self.checkConfig()
+
+    def copy(self) -> Instrument:
+        """Return a deep copy of the instrument.
+
+        Notes
+        -----
+        Any cached data from the original instrument will need to be
+        repopulated in the copied instrument.
+        """
+        return Instrument(
+            name=self.name,
+            diameter=self.diameter,
+            obscuration=self.obscuration,
+            focalLength=self.focalLength,
+            defocalOffset=self.defocalOffset,
+            pixelSize=self.pixelSize,
+            refBand=self.refBand,
+            wavelength=self.wavelength,
+            batoidModelName=self.batoidModelName,
+            batoidOffsetOptic=self.batoidOffsetOptic,
+            batoidOffsetValue=self.batoidOffsetValue,
+            maskParams=self.maskParams,
+        )
 
     def checkConfig(self) -> None:
         """Access every attribute to make sure no errors are thrown."""

--- a/python/lsst/ts/wep/task/estimateZernikesDanishTask.py
+++ b/python/lsst/ts/wep/task/estimateZernikesDanishTask.py
@@ -38,6 +38,12 @@ class EstimateZernikesDanishConfig(EstimateZernikesBaseConfig):
         doc="A dictionary containing any of the keyword arguments for "
         + "scipy.optimize.least_squares, except `fun`, `x0`, `jac`, or `args`.",
     )
+    binning = pexConfig.Field(
+        dtype=int,
+        default=1,
+        doc="Binning factor to apply to the donut stamps before estimating "
+        + "Zernike coefficients. A value of 1 means no binning.",
+    )
 
 
 class EstimateZernikesDanishTask(EstimateZernikesBaseTask):

--- a/python/lsst/ts/wep/task/estimateZernikesTieTask.py
+++ b/python/lsst/ts/wep/task/estimateZernikesTieTask.py
@@ -110,6 +110,12 @@ class EstimateZernikesTieConfig(EstimateZernikesBaseConfig):
         + "when estimating Zernikes with a single donut. "
         + "(the default is 2)",
     )
+    binning = pexConfig.Field(
+        dtype=int,
+        default=1,
+        doc="Binning factor to apply to the donut stamps before estimating "
+        + "Zernike coefficients. A value of 1 means no binning.",
+    )
 
 
 class EstimateZernikesTieTask(EstimateZernikesBaseTask):

--- a/python/lsst/ts/wep/utils/miscUtils.py
+++ b/python/lsst/ts/wep/utils/miscUtils.py
@@ -27,6 +27,7 @@ __all__ = [
     "centerWithTemplate",
     "polygonContains",
     "conditionalSigmaClip",
+    "binArray",
 ]
 
 import numba
@@ -432,3 +433,30 @@ def conditionalSigmaClip(
             processedArray[:, i] = clipped.filled(np.nan)
 
     return processedArray
+
+
+def binArray(array: np.ndarray, binning: int) -> np.ndarray:
+    """Bin a 2d array by averaging over non-overlapping blocks.
+
+    Parameters
+    ----------
+    array : np.ndarray
+        The 2d array to be binned
+    binning : int
+        The binning factor
+
+    Returns
+    -------
+    np.ndarray
+        The binned array
+    """
+    # Ensure the array is divisible by the binning factor
+    array = array[
+        : array.shape[0] // binning * binning, : array.shape[1] // binning * binning
+    ]
+    # Bin the array
+    binned = array.reshape(
+        array.shape[0] // binning, binning, array.shape[1] // binning, binning
+    ).mean(axis=(1, 3))
+
+    return binned

--- a/tests/estimation/test_danish.py
+++ b/tests/estimation/test_danish.py
@@ -52,11 +52,24 @@ class TestDanishAlgorithm(unittest.TestCase):
     def testAccuracy(self):
         # Create estimator
         dan = DanishAlgorithm()
+        danBin = DanishAlgorithm(binning=2)
 
         # Try several different random seeds
         for seed in [12345, 23451, 34512, 45123, 51234]:
             # Get the test data
             zkTrue, intra, extra = forwardModelPair(seed=seed)
+
+            # Compute shape of binned images
+            shapex, shapey = intra.image.shape
+            binned_shapex = shapex // 2
+            binned_shapey = shapey // 2
+
+            # Ensure odd
+            if binned_shapex % 2 == 0:
+                binned_shapex -= 1
+            if binned_shapey % 2 == 0:
+                binned_shapey -= 1
+            binned_shape = (binned_shapex, binned_shapey)
 
             # Test estimation with pairs and single donuts:
             for images in [[intra, extra], [intra], [extra]]:
@@ -65,3 +78,17 @@ class TestDanishAlgorithm(unittest.TestCase):
 
                 # Check that results are fairly accurate
                 self.assertLess(np.sqrt(np.sum((zkEst - zkTrue) ** 2)), 0.35e-6)
+
+                # Test with binning
+                zkEst = danBin.estimateZk(*images, saveHistory=True)
+                self.assertLess(np.sqrt(np.sum((zkEst - zkTrue) ** 2)), 0.35e-6)
+
+                # Test that we binned the images.
+                if "intra" in danBin.history:
+                    self.assertEqual(
+                        danBin.history["intra"]["image"].shape, binned_shape
+                    )
+                if "extra" in danBin.history:
+                    self.assertEqual(
+                        danBin.history["extra"]["image"].shape, binned_shape
+                    )

--- a/tests/estimation/test_tie.py
+++ b/tests/estimation/test_tie.py
@@ -64,14 +64,28 @@ class TestTieAlgorithm(unittest.TestCase):
             # Get the test data
             zkTrue, intra, extra = forwardModelPair(seed=seed)
 
+            # Compute shape of binned images
+            binned_shape = tuple(sh // 2 for sh in intra.image.shape)
+
             # Create estimator
             tie = TieAlgorithm()
+            tieBin = TieAlgorithm(binning=2)
 
             # Estimate Zernikes (in meters)
             zkEst = tie.estimateZk(intra, extra)
 
             # Check that results are fairly accurate
             self.assertLess(np.sqrt(np.sum((zkEst - zkTrue) ** 2)), 0.35e-6)
+
+            # Test with binning
+            zkEst = tieBin.estimateZk(intra, extra, saveHistory=True)
+            self.assertLess(np.sqrt(np.sum((zkEst - zkTrue) ** 2)), 0.35e-6)
+
+            # Test that we binned the images.
+            self.assertEqual(tieBin.history[0]["intraInit"].shape, binned_shape)
+            self.assertEqual(tieBin.history[0]["extraInit"].shape, binned_shape)
+            self.assertEqual(tieBin.history[1]["intraCent"].shape, binned_shape)
+            self.assertEqual(tieBin.history[1]["extraCent"].shape, binned_shape)
 
     def testSaveHistory(self):
         # Run the algorithm


### PR DESCRIPTION
Adds config option to both TIE and danish to bin the donut stamps before estimating the wavefront.  In some spot checks, the accuracy difference appears negligible while the speed up is ~3x for TIE and ~2x for danish.