### PR TITLE
DM-46414: Add `zernikes` astropy table output from CalcZernikesTask

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-11.5.0:
+
+-------------
+11.5.0
+-------------
+
+* Add astropy table output to CalcZernikesTask.
+
 .. _lsst.ts.wep-11.4.2:
 
 -------------

--- a/tests/estimation/test_tie.py
+++ b/tests/estimation/test_tie.py
@@ -142,7 +142,6 @@ class TestTieAlgorithm(unittest.TestCase):
         }
         for iteration in hist.values():
             for key, val in contents.items():
-                print(type(iteration[key]))
                 self.assertIsInstance(iteration.pop(key), val)
 
             # Check that was all that was in the history

--- a/tests/task/test_calcZernikesTieTaskScienceSensor.py
+++ b/tests/task/test_calcZernikesTieTaskScienceSensor.py
@@ -24,6 +24,7 @@ import os
 import lsst.utils.tests
 import numpy as np
 import pandas as pd
+from astropy.table import QTable
 from lsst.daf import butler as dafButler
 from lsst.ts.wep.task import (
     CalcZernikesTask,
@@ -137,8 +138,8 @@ class TestCalcZernikesTieTaskScienceSensor(lsst.utils.tests.TestCase):
         )
         structNormal = self.task.run(donutStampsIntra, donutStampsExtra)
 
-        # check that 4 elements are created
-        self.assertEqual(len(structNormal), 4)
+        # check that 5 elements are created
+        self.assertEqual(len(structNormal), 5)
 
         # Turn on the donut stamp selector
         self.task.doDonutStampSelector = True
@@ -170,6 +171,7 @@ class TestCalcZernikesTieTaskScienceSensor(lsst.utils.tests.TestCase):
             self.assertIsInstance(struct.donutsExtraQuality, pd.DataFrame)
             self.assertIsInstance(struct.outputZernikesRaw, np.ndarray)
             self.assertIsInstance(struct.outputZernikesAvg, np.ndarray)
+            self.assertIsInstance(struct.zernikes, QTable)
 
     def testGetCombinedZernikes(self):
         testArr = np.zeros((2, 19))

--- a/tests/task/test_cutOutDonutsBase.py
+++ b/tests/task/test_cutOutDonutsBase.py
@@ -206,7 +206,7 @@ class TestCutOutDonutsBase(lsst.utils.tests.TestCase):
         np.testing.assert_array_equal(initCornerY, cornerY)
 
         # Also check the peak height for the centered exposure
-        np.testing.assert_array_almost_equal(peakHeight, np.ones(2) * 9471.999796846694)
+        self.assertFloatsAlmostEqual(peakHeight, 9472.0, rtol=0, atol=3e-4)
 
     def testCalcFinalCentroidsOnEdge(self):
         (
@@ -231,9 +231,7 @@ class TestCutOutDonutsBase(lsst.utils.tests.TestCase):
         np.testing.assert_array_equal(cornerX, np.array([0, initCornerX[1]]))
         np.testing.assert_array_equal(cornerY, np.array([0, initCornerY[1]]))
         # Also check the peak height for the off-center exposure
-        np.testing.assert_array_almost_equal(
-            peakHeight, np.array([8943.999944194224, 9471.999796846694])
-        )
+        self.assertFloatsAlmostEqual(peakHeight, [8944.0, 9472.0], rtol=0, atol=3e-4)
 
     def testMaxRecenter(self):
         maxRecenter = 5


### PR DESCRIPTION
This combines the current outputs from `outputZernikesRaw` and `outputZernikesAvg` into a single new dataset type, using `astropy.table.QTable` as the storage class.  Some features:
* There are individual named columns for each Zernike coefficient, so we can easily adapt this to sparse indexing in a future commit.  
* The QTable tracks units.  
* Each row is a different donut pair (we'll have to adapt in the future when we get tasks for running on a single side of focus).  
* There's a bonus row with a label "average" to place what used to be in `outputZernikesAvg`.  
 
Here's a quick preview of the format:

```csv
 label  used      intra_field [x, y]           extra_field [x, y]      ...         Z26                 Z27                 Z28        
                         deg                          deg              ...          nm                  nm                  nm        
------- ---- ---------------------------- ---------------------------- ... -------------------- ------------------ -------------------
average True                   (nan, nan)                   (nan, nan) ...   2.3800891163369617  41.22152418083769 -35.277507712739755
  pair1 True    (-0.05821145, 0.02770254)    (-0.05815588, 0.02764697) ...   2.9741328684160266  47.96728907450128 -51.641467608636205
  pair2 True (-0.03042558, -8.335776e-05) (-0.03042558, -8.335776e-05) ...    4.752704920327202 33.015250747032304 -40.203176051984826
  pair3 True     (0.02509067, 0.05548844)      (0.02509067, 0.0553773) ...   2.7752296616889507 33.957946113380295 -38.249810630913444
  pair4 True     (0.05287657, 0.02770254)       (0.052821, 0.02764697) ...  0.29520949398193513  40.05030889181167 -24.009861860875446
  pair5 True     (0.02509068, 0.02770256)     (0.02509068, 0.02764699) ...   3.3179267030988275   42.3718751313613 -27.333083707839172
  pair6 True  (0.05287658, -8.335772e-05)  (0.05282101, -8.335772e-05) ...   -2.446922617228806   43.8753425268592 -29.423867896649814
  pair7 True (0.02514626, -8.3357765e-05) (0.02509069, -8.3357765e-05) ...   0.5340847698338642  44.76449641394313 -37.178195535420855
  pair8 True    (0.05287657, -0.02786926)      (0.052821, -0.02786926) ...  -3.4206912611860387   46.0229076067933 -17.539900548414202
  pair9 True    (0.02514626, -0.02786927)    (0.02509068, -0.02786927) ...    5.105795693358347  48.71401822551286  -20.10808049221983
 pair10 True    (0.05287654, -0.05559955)    (0.05282096, -0.05559955) ...  -3.4056012162811595  45.10249008751407  -24.72798750910216
 pair11 True    (0.02514624, -0.05565516)    (0.02509067, -0.05559959) ...  0.29033472810139616  51.69241538940008 -37.505699063741375
 pair12 True (-0.00263966, -8.335778e-05) (-0.00269523, -8.335778e-05) ...   0.6741125757416147 41.692103185536034  -40.30476570000266
 pair13 True (-0.05821146, -8.335771e-05)   (-0.05815589, -0.00013893) ...   2.4613671878413927  44.89664184602307  -47.91856854826923
 pair14 True    (-0.03042558, 0.02770256)    (-0.03042558, 0.02764698) ...   3.1608577327658733  41.07589462243317  -36.56538855134798
 pair15 True   (-0.00263966, -0.02786928)   (-0.00269523, -0.02786928) ...   3.9095785158717464  38.13166417802683  -34.02817058690904
 pair16 True   (-0.03042558, -0.02786927)   (-0.03042558, -0.02786927) ... -0.01614557753727189  41.10125358279642  -49.52202476660966
 pair17 True   (-0.05821145, -0.02786925)   (-0.05815588, -0.02786925) ...   1.0207957206965301  42.59523394110048 -42.839296409741536
 pair18 True   (-0.00263966, -0.05565517)   (-0.00269523, -0.05559959) ...    5.901836013265612  45.98010582607783  -38.41669740030114
 pair19 True   (-0.03042556, -0.05565515)   (-0.03042556, -0.05559958) ...   10.110786071826995  33.36011368015603  -32.42363023338399
 pair20 True   (-0.05821142, -0.05565511)   (-0.05815584, -0.05559954) ...    7.748251120039328  36.77703640498484  -26.39317864515166
 pair21 True    (-0.00269523, 0.05548845)    (-0.00269523, 0.05537731) ...    4.640904016777619 35.467498877988206  -35.71493852268121
 pair22 True    (-0.03042556, 0.05548844)    (-0.03042556, 0.05537729) ...   3.9559868574106636  40.52591641143584  -39.30718665348717
 pair23 True     (-0.05821142, 0.0554884)    (-0.05815585, 0.05537726) ...   1.0348728236687468   39.9540878313354  -36.47176481982561
 pair24 True    (-0.00263966, 0.02770256)    (-0.00269523, 0.02764699) ...    6.257958042481342  36.61132670044153  -36.26792424702971
 pair25 True     (0.05287654, 0.05548841)     (0.05282097, 0.05537726) ...  -2.1311369365367043  34.83488722449716  -37.84302682795591
```

QTables can also hold metadata, so before this gets merged, I'd like to propagate some other items like the camera rotator and boresight pointing.  It'd be nice to propagate the flux and blends from donutCat into the rows here too; aggregate everything in one place.