### PR TITLE
Increase RA stamp size

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-12.4.2:
+
+-------------
+12.4.2
+-------------
+
+* Increase stamp size in Rapid Analysis pipeline to avoid clipping donut edges.
+
 .. _lsst.ts.wep-12.4.1:
 
 -------------

--- a/pipelines/production/comCamRapidAnalysisPipeline.yaml
+++ b/pipelines/production/comCamRapidAnalysisPipeline.yaml
@@ -12,7 +12,7 @@ tasks:
       python: |
         from lsst.ts.wep.task.pairTask import GroupPairer
         config.pairer.retarget(GroupPairer)
-      donutStampSize: 160
+      donutStampSize: 200
       initialCutoutPadding: 40
   calcZernikesTask:
     class: lsst.ts.wep.task.calcZernikesTask.CalcZernikesTask


### PR DESCRIPTION
I propose to increase the stamp size in RA pipelines to make sure that donut edges aren't getting clipped.

For example, with stamp size = 160:
<img width="186" alt="image" src="https://github.com/user-attachments/assets/d15f1a5f-e649-465e-a507-bd528e9a9ae0">
