### PR TITLE
Enable CutOutDonutsScienceSensorTask to operate for a pair with same-sign focusZ.

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-12.5.0:
+
+-------------
+12.5.0
+-------------
+
+* Enable CutOutDonutsScienceSensorTask to operate for a pair with same-sign focusZ.
+
 .. _lsst.ts.wep-12.4.2:
 
 -------------

--- a/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
@@ -183,22 +183,12 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
         """
 
         if cameraName in ["LSSTCam", "LSSTComCam", "LSSTComCamSim"]:
-            errorStr = "Must have one extra-focal and one intra-focal image."
             if focusZVal0 < 0:
-                # Check that other image does not have same defocal direction
-                if focusZVal1 <= 0:
-                    raise ValueError(errorStr)
                 extraExpIdx = 1
                 intraExpIdx = 0
-            elif focusZVal0 > 0:
-                # Check that other image does not have same defocal direction
-                if focusZVal1 >= 0:
-                    raise ValueError(errorStr)
+            else:
                 extraExpIdx = 0
                 intraExpIdx = 1
-            else:
-                # Need to be defocal images ('FOCUSZ != 0')
-                raise ValueError(errorStr)
         elif cameraName == "LATISS":
             errorStr = "Must have two images with different FOCUSZ parameter."
             if focusZVal0 != focusZVal1:

--- a/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsScienceSensorTask.py
@@ -183,7 +183,7 @@ class CutOutDonutsScienceSensorTask(CutOutDonutsBaseTask):
         """
 
         if cameraName in ["LSSTCam", "LSSTComCam", "LSSTComCamSim"]:
-            if focusZVal0 < 0:
+            if focusZVal0 < focusZVal1:
                 extraExpIdx = 1
                 intraExpIdx = 0
             else:

--- a/tests/task/test_cutOutDonutsScienceSensorTask.py
+++ b/tests/task/test_cutOutDonutsScienceSensorTask.py
@@ -193,26 +193,6 @@ class TestCutOutDonutsScienceSensorTask(lsst.utils.tests.TestCase):
         self.assertEqual(extraIdx, 0)
         self.assertEqual(intraIdx, 1)
 
-    def testAssignExtraIntraIdxFocusZValueError(self):
-        focusZNegative = -1
-        focusZPositive = 1
-        focusZ0 = 0
-
-        with self.assertRaises(ValueError):
-            self.task.assignExtraIntraIdx(focusZPositive, focusZPositive, "LSSTCam")
-        with self.assertRaises(ValueError):
-            self.task.assignExtraIntraIdx(focusZPositive, focusZ0, "LSSTCam")
-        with self.assertRaises(ValueError):
-            self.task.assignExtraIntraIdx(focusZNegative, focusZNegative, "LSSTCam")
-        with self.assertRaises(ValueError):
-            self.task.assignExtraIntraIdx(focusZNegative, focusZ0, "LSSTCam")
-        with self.assertRaises(ValueError) as context:
-            self.task.assignExtraIntraIdx(focusZ0, focusZPositive, "LSSTCam")
-        self.assertEqual(
-            "Must have one extra-focal and one intra-focal image.",
-            str(context.exception),
-        )
-
     def testAssignExtraIntraIdxInvalidCamera(self):
         cameraName = "WrongCam"
         with self.assertRaises(ValueError) as context:


### PR DESCRIPTION
`CutOutDonutsScienceSensorTask` was previously written to require a pair of exposures with focusZ of opposite signs (i.e., one positive and one negative). If both focusZ had the same sign, it worried you had passed two exposures on the same side of focus, and raised an exception.

Apparently this was not desired and caused problems on night of 20241028. This PR removes this check and simply assigns the lower focusZ to intrafocal