### PR TITLE
tickets/DM-47251: Added maxSelect to DonutStampsSelector

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-12.6.0:
+
+-------------
+12.6.0
+-------------
+
+* Added maxSelect config to DonutStampsSelector
+
 .. _lsst.ts.wep-12.5.0:
 
 -------------

--- a/pipelines/production/comCamRapidAnalysisPipeline.yaml
+++ b/pipelines/production/comCamRapidAnalysisPipeline.yaml
@@ -5,7 +5,7 @@ tasks:
     class: lsst.ts.wep.task.generateDonutDirectDetectTask.GenerateDonutDirectDetectTask
     config:
       donutSelector.useCustomMagLimit: True
-      donutSelector.sourceLimit: 5
+      donutSelector.sourceLimit: 20
   cutOutDonutsScienceSensorGroupTask:
     class: lsst.ts.wep.task.cutOutDonutsScienceSensorTask.CutOutDonutsScienceSensorTask
     config:
@@ -20,6 +20,7 @@ tasks:
       estimateZernikes.maxNollIndex: 28
       estimateZernikes.saveHistory: False
       estimateZernikes.maskKwargs: { "doMaskBlends": False }
+      donutStampSelector.maxSelect: 5
   isr:
     class: lsst.ip.isr.IsrTaskLSST
     config:

--- a/python/lsst/ts/wep/task/donutStampSelectorTask.py
+++ b/python/lsst/ts/wep/task/donutStampSelectorTask.py
@@ -31,6 +31,11 @@ from lsst.utils.timer import timeMethod
 
 
 class DonutStampSelectorTaskConfig(pexConfig.Config):
+    maxSelect = pexConfig.Field(
+        dtype=int,
+        default=5,
+        doc="Maximum number of donut stamps to select. If -1, all are selected.",
+    )
     selectWithEntropy = pexConfig.Field(
         dtype=bool,
         default=False,
@@ -224,6 +229,10 @@ class DonutStampSelectorTask(pipeBase.Task):
 
         # choose only donuts that satisfy all selected conditions
         selected = entropySelect * snSelect * fracBadPixSelect
+
+        # make sure we don't select more than maxSelect
+        if self.config.maxSelect != -1:
+            selected[np.cumsum(selected) > self.config.maxSelect] = False
 
         # store information about which donuts were selected
         # use QTable even though no units at the moment in


### PR DESCRIPTION
This PR implements a `maxSelect` config in `DonutStampsSelectorTask` to limit the number of stamps selected for Zernike estimation. We can now raise the number of stamps cutout, and allow this to throttle the number of Zernike estimates. This should ensure we get the same number of stamps per detector.