### PR TITLE
Tickets/DM-44529: fix generateDonutDirectDetect for null selection

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-13.3.2:
+
+-------------
+13.3.2
+-------------
+
+* Fix generateDonutDirectDetect for null donut selection.
+
 .. _lsst.ts.wep-13.3.1:
 
 -------------

--- a/python/lsst/ts/wep/task/cutOutDonutsBase.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsBase.py
@@ -611,36 +611,38 @@ reducing the amount of donut mask dilation to {self.bkgDilationIter}"
             # Save centroid positions as str so we can store in header
             blendStrX = ""
             blendStrY = ""
-
-            for blend_cx, blend_cy in zip(
-                catalogMeta["blend_centroid_x"][idx],
-                catalogMeta["blend_centroid_y"][idx],
-            ):
-                blend_final_x = blend_cx + donutRow["xShift"]
-                blend_final_y = blend_cy + donutRow["yShift"]
-                blendStrX += f"{blend_final_x:.2f},"
-                blendStrY += f"{blend_final_y:.2f},"
-            # Remove comma from last entry
-            if len(blendStrX) > 0:
-                blendStrX = blendStrX[:-1]
-                blendStrY = blendStrY[:-1]
-            else:
-                blendStrX = None
-                blendStrY = None
-            finalBlendXList.append(blendStrX)
-            finalBlendYList.append(blendStrY)
+            if len(catalogMeta["blend_centroid_x"])>0:
+                for blend_cx, blend_cy in zip(
+                    catalogMeta["blend_centroid_x"][idx],
+                    catalogMeta["blend_centroid_y"][idx],
+                ):
+                    blend_final_x = blend_cx + donutRow["xShift"]
+                    blend_final_y = blend_cy + donutRow["yShift"]
+                    blendStrX += f"{blend_final_x:.2f},"
+                    blendStrY += f"{blend_final_y:.2f},"
+                # Remove comma from last entry
+                if len(blendStrX) > 0:
+                    blendStrX = blendStrX[:-1]
+                    blendStrY = blendStrY[:-1]
+                else:
+                    blendStrX = None
+                    blendStrY = None
+                finalBlendXList.append(blendStrX)
+                finalBlendYList.append(blendStrY)
 
             # Prepare blend centroid position information
-            if len(catalogMeta["blend_centroid_x"][idx]) > 0:
-                blendCentroidPositions = np.array(
-                    [
-                        catalogMeta["blend_centroid_x"][idx] + donutRow["xShift"],
-                        catalogMeta["blend_centroid_y"][idx] + donutRow["yShift"],
-                    ]
-                ).T
+            if len(catalogMeta["blend_centroid_x"]) > 0:
+                if len(catalogMeta["blend_centroid_x"][idx]) > 0:
+                    blendCentroidPositions = np.array(
+                        [
+                            catalogMeta["blend_centroid_x"][idx] + donutRow["xShift"],
+                            catalogMeta["blend_centroid_y"][idx] + donutRow["yShift"],
+                        ]
+                    ).T
+                else:
+                    blendCentroidPositions = np.array([["nan"], ["nan"]], dtype=float).T
             else:
                 blendCentroidPositions = np.array([["nan"], ["nan"]], dtype=float).T
-
             # Get the local linear WCS for the donut stamp
             # Be careful to get the cd matrix from the linearized WCS instead
             # of the one from the full WCS.

--- a/python/lsst/ts/wep/task/cutOutDonutsBase.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsBase.py
@@ -608,10 +608,13 @@ reducing the amount of donut mask dilation to {self.bkgDilationIter}"
             # Save MaskedImage to stamp
             finalStamp = finalCutout.getMaskedImage()
 
-            # Save centroid positions as str so we can store in header
-            blendStrX = ""
-            blendStrY = ""
+            # Set that as default, unless overwritten
+            blendCentroidPositions = np.array([["nan"], ["nan"]], dtype=float).T
+
             if len(catalogMeta["blend_centroid_x"]) > 0:
+                # Save centroid positions as str so we can store in header
+                blendStrX = ""
+                blendStrY = ""
                 for blend_cx, blend_cy in zip(
                     catalogMeta["blend_centroid_x"][idx],
                     catalogMeta["blend_centroid_y"][idx],
@@ -630,8 +633,7 @@ reducing the amount of donut mask dilation to {self.bkgDilationIter}"
                 finalBlendXList.append(blendStrX)
                 finalBlendYList.append(blendStrY)
 
-            # Prepare blend centroid position information
-            if len(catalogMeta["blend_centroid_x"]) > 0:
+                # Prepare blend centroid position information
                 if len(catalogMeta["blend_centroid_x"][idx]) > 0:
                     blendCentroidPositions = np.array(
                         [
@@ -639,10 +641,7 @@ reducing the amount of donut mask dilation to {self.bkgDilationIter}"
                             catalogMeta["blend_centroid_y"][idx] + donutRow["yShift"],
                         ]
                     ).T
-                else:
-                    blendCentroidPositions = np.array([["nan"], ["nan"]], dtype=float).T
-            else:
-                blendCentroidPositions = np.array([["nan"], ["nan"]], dtype=float).T
+
             # Get the local linear WCS for the donut stamp
             # Be careful to get the cd matrix from the linearized WCS instead
             # of the one from the full WCS.

--- a/python/lsst/ts/wep/task/cutOutDonutsBase.py
+++ b/python/lsst/ts/wep/task/cutOutDonutsBase.py
@@ -611,7 +611,7 @@ reducing the amount of donut mask dilation to {self.bkgDilationIter}"
             # Save centroid positions as str so we can store in header
             blendStrX = ""
             blendStrY = ""
-            if len(catalogMeta["blend_centroid_x"])>0:
+            if len(catalogMeta["blend_centroid_x"]) > 0:
                 for blend_cx, blend_cy in zip(
                     catalogMeta["blend_centroid_x"][idx],
                     catalogMeta["blend_centroid_y"][idx],

--- a/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
+++ b/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
@@ -220,13 +220,13 @@ class GenerateDonutDirectDetectTask(pipeBase.PipelineTask):
             An empty donut table with correct columns.
         """
         donutColumns = [
-                "coord_ra",
-                "coord_dec",
-                "centroid_x",
-                "centroid_y",
-                "detector",
-                "source_flux",
-            ]
+            "coord_ra",
+            "coord_dec",
+            "centroid_x",
+            "centroid_y",
+            "detector",
+            "source_flux",
+        ]
         donutTable = QTable(names=donutColumns)
         donutTable.meta["blend_centroid_x"] = ""
         donutTable.meta["blend_centroid_y"] = ""
@@ -306,7 +306,7 @@ class GenerateDonutDirectDetectTask(pipeBase.PipelineTask):
             # donut table
             else:
                 self.log.warning(
-                "No sources selected in the exposure. Returning an empty donut catalog."
+                    "No sources selected in the exposure. Returning an empty donut catalog."
                 )
                 donutCatUpd = self.emptyTable()
         else:

--- a/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
+++ b/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
@@ -199,12 +199,17 @@ class GenerateDonutDirectDetectTask(pipeBase.PipelineTask):
         ]
         donutCatUpd["source_flux"] = donutCat["source_flux"] * u.nJy
         fluxSort = np.argsort(donutCatUpd["source_flux"])[::-1]
-        donutCatUpd.meta["blend_centroid_x"] = [
-            donutCat.meta["blend_centroid_x"][idx] for idx in fluxSort
-        ]
-        donutCatUpd.meta["blend_centroid_y"] = [
-            donutCat.meta["blend_centroid_y"][idx] for idx in fluxSort
-        ]
+        # It is possible for catalog to have multiple sources
+        # detected, but with source selection turned off
+        # the QTable metadata of `blend_centroid_x` and
+        # `blend_centroid_y` will be empty.
+        if self.config.doDonutSelection:
+            donutCatUpd.meta["blend_centroid_x"] = [
+                donutCat.meta["blend_centroid_x"][idx] for idx in fluxSort
+            ]
+            donutCatUpd.meta["blend_centroid_y"] = [
+                donutCat.meta["blend_centroid_y"][idx] for idx in fluxSort
+            ]
 
         donutCatUpd.sort("source_flux", reverse=True)
 

--- a/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
+++ b/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
@@ -307,7 +307,7 @@ class GenerateDonutDirectDetectTask(pipeBase.PipelineTask):
                 donutCatUpd["detector"] = np.array(
                     [detectorName] * len(donutCatUpd), dtype=str
                 )
-            # If no donuts got selected, issue a warning and return an enpy
+            # If no donuts got selected, issue a warning and return an empty
             # donut table
             else:
                 self.log.warning(

--- a/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
+++ b/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
@@ -282,6 +282,11 @@ class GenerateDonutDirectDetectTask(pipeBase.PipelineTask):
             # Use the aperture flux with a 70 pixel aperture
             donutTable[f"{bandLabel}_flux"] = donutTable["apFlux70"]
 
+            # Set the required columns to be empty, unless
+            # overwritten by donutSelector below
+            donutTable.meta["blend_centroid_x"] = ""
+            donutTable.meta["blend_centroid_y"] = ""
+
             # Run the donut selector task.
             if self.config.doDonutSelection:
                 self.log.info("Running Donut Selector")
@@ -292,10 +297,6 @@ class GenerateDonutDirectDetectTask(pipeBase.PipelineTask):
                 donutCatSelected.meta["blend_centroid_x"] = donutSelection.blendCentersX
                 donutCatSelected.meta["blend_centroid_y"] = donutSelection.blendCentersY
             else:
-                # if donut selector was not run,
-                # set the required columns to be empty
-                donutTable.meta["blend_centroid_x"] = ""
-                donutTable.meta["blend_centroid_y"] = ""
                 donutCatSelected = donutTable
 
             donutCatSelected.rename_column(f"{bandLabel}_flux", "source_flux")

--- a/tests/task/test_generateDonutDirectDetectTask.py
+++ b/tests/task/test_generateDonutDirectDetectTask.py
@@ -301,6 +301,21 @@ class TestGenerateDonutDirectDetectTask(lsst.utils.tests.TestCase):
         self.assertCountEqual(
             taskOut_S11_noSelection.donutCatalog.columns, expected_columns
         )
+        # Check that the length of catalogs is as expected
+        outputTableNoSel = taskOut_S11_noSelection.donutCatalog
+        self.assertEqual(len(outputTableNoSel), 3)
+
+        # Test against truth the centroid for all sources
+        result_y = np.sort(outputTableNoSel["centroid_y"].value)
+        truth_y = np.sort(np.array([3196, 2196, 398]))
+        diff_y = np.sum(result_y - truth_y)
+
+        result_x = np.sort(outputTableNoSel["centroid_x"].value)
+        truth_x = np.sort(np.array([3812, 2814, 618]))
+        diff_x = np.sum(result_x - truth_x)
+
+        self.assertLess(diff_x, tolerance)
+        self.assertLess(diff_y, tolerance)
 
     def testTaskRunPipeline(self):
         """

--- a/tests/task/test_generateDonutDirectDetectTask.py
+++ b/tests/task/test_generateDonutDirectDetectTask.py
@@ -156,13 +156,13 @@ class TestGenerateDonutDirectDetectTask(lsst.utils.tests.TestCase):
         self.assertEqual(len(testTable), 0)
 
         expected_columns = [
-                    "coord_ra",
-                    "coord_dec",
-                    "centroid_x",
-                    "centroid_y",
-                    "detector",
-                    "source_flux",
-                ]
+            "coord_ra",
+            "coord_dec",
+            "centroid_x",
+            "centroid_y",
+            "detector",
+            "source_flux",
+        ]
         self.assertCountEqual(testTable.columns, expected_columns)
 
     def testTaskRun(self):
@@ -214,8 +214,8 @@ class TestGenerateDonutDirectDetectTask(lsst.utils.tests.TestCase):
         # Test that all expected metadata keys are present
         expected_metakeys = ["blend_centroid_x", "blend_centroid_y", "visit_info"]
         self.assertCountEqual(
-            taskOutNoSrc.donutCatalog.meta.keys(), expected_metakeys
-            ,
+            taskOutNoSrc.donutCatalog.meta.keys(),
+            expected_metakeys,
         )
 
         # Run detection with different sources in each exposure
@@ -263,17 +263,17 @@ class TestGenerateDonutDirectDetectTask(lsst.utils.tests.TestCase):
 
         # Run the task
         taskOut_S10_noSel = self.task.run(
-                        exposure_S10,
-                        camera,
-                    )
+            exposure_S10,
+            camera,
+        )
 
         # Test that there are no rows, but all columns are present
         self.assertCountEqual(taskOut_S10_noSel.donutCatalog.columns, expected_columns)
 
         # Test that all expected metadata keys are present
         self.assertCountEqual(
-            taskOut_S10_noSel.donutCatalog.meta.keys(), expected_metakeys
-            ,
+            taskOut_S10_noSel.donutCatalog.meta.keys(),
+            expected_metakeys,
         )
 
     def testTaskRunPipeline(self):


### PR DESCRIPTION
This PR adds a fix to the direct detection task, whereby if sources are detected, but none selected via `donutSelector`, the task would produce an error failing entire pipeline. Now it will return a `warning` similar to the case of no donuts detected, alongside with an empty donut table.  