### PR TITLE
Tickets/DM-48706: safeguard against edge donuts

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.wep-13.4.0:
+
+-------------
+13.4.0
+-------------
+
+* Safeguard against edge donuts at detection stage with edgeMargin parameter.
+
 .. _lsst.ts.wep-13.3.4:
 
 -------------

--- a/python/lsst/ts/wep/task/generateDonutCatalogOnlineTask.py
+++ b/python/lsst/ts/wep/task/generateDonutCatalogOnlineTask.py
@@ -107,7 +107,7 @@ class GenerateDonutCatalogOnlineTask(pipeBase.Task):
         # refObjLoader handles the interaction with the butler repository
         # needed to get the pieces of the reference catalogs we need.
         refObjLoader = self.getRefObjLoader(refCatalogs)
-        margin = self.config.edgeMargin
+        edgeMargin = self.config.edgeMargin
         filterName = self.config.filterName
 
         try:
@@ -121,7 +121,7 @@ class GenerateDonutCatalogOnlineTask(pipeBase.Task):
                 detectorWcs,
                 filterName,
                 donutSelectorTask,
-                margin,
+                edgeMargin,
             )
 
         # Except RuntimeError caused when no reference catalog

--- a/python/lsst/ts/wep/task/generateDonutCatalogOnlineTask.py
+++ b/python/lsst/ts/wep/task/generateDonutCatalogOnlineTask.py
@@ -45,6 +45,9 @@ class GenerateDonutCatalogOnlineTaskConfig(pexConfig.Config):
     doDonutSelection = pexConfig.Field(
         doc="Whether or not to run donut selector.", dtype=bool, default=True
     )
+    edgeMargin = pexConfig.Field(
+        doc="Size of detector edge margin in pixels", dtype=int, default=80
+    )
 
 
 class GenerateDonutCatalogOnlineTask(pipeBase.Task):
@@ -104,7 +107,7 @@ class GenerateDonutCatalogOnlineTask(pipeBase.Task):
         # refObjLoader handles the interaction with the butler repository
         # needed to get the pieces of the reference catalogs we need.
         refObjLoader = self.getRefObjLoader(refCatalogs)
-
+        margin = self.config.edgeMargin
         filterName = self.config.filterName
 
         try:
@@ -113,7 +116,12 @@ class GenerateDonutCatalogOnlineTask(pipeBase.Task):
                 self.donutSelector if self.config.doDonutSelection is True else None
             )
             refSelection, blendCentersX, blendCentersY = runSelection(
-                refObjLoader, detector, detectorWcs, filterName, donutSelectorTask
+                refObjLoader,
+                detector,
+                detectorWcs,
+                filterName,
+                donutSelectorTask,
+                margin,
             )
 
         # Except RuntimeError caused when no reference catalog

--- a/python/lsst/ts/wep/task/generateDonutCatalogUtils.py
+++ b/python/lsst/ts/wep/task/generateDonutCatalogUtils.py
@@ -35,7 +35,9 @@ from lsst.daf.base import DateTime
 from lsst.geom import SpherePoint, degrees, radians
 
 
-def runSelection(refObjLoader, detector, wcs, filterName, donutSelectorTask, edgeMargin):
+def runSelection(
+    refObjLoader, detector, wcs, filterName, donutSelectorTask, edgeMargin
+):
     """
     Match the detector area to the reference catalog
     and then run the LSST DM reference selection task.

--- a/python/lsst/ts/wep/task/generateDonutCatalogUtils.py
+++ b/python/lsst/ts/wep/task/generateDonutCatalogUtils.py
@@ -35,7 +35,7 @@ from lsst.daf.base import DateTime
 from lsst.geom import SpherePoint, degrees, radians
 
 
-def runSelection(refObjLoader, detector, wcs, filterName, donutSelectorTask):
+def runSelection(refObjLoader, detector, wcs, filterName, donutSelectorTask, edgeMargin):
     """
     Match the detector area to the reference catalog
     and then run the LSST DM reference selection task.
@@ -57,6 +57,9 @@ def runSelection(refObjLoader, detector, wcs, filterName, donutSelectorTask):
         Task to run the donut source selection algorithm. If set to None,
         the catalog will be the exact same as the reference catalogs without
         any donut selection algorithm applied.
+    edgeMargin: `int`
+        The width of the margin by which we decrease bbox to avoid edge
+        source selection.
 
     Returns
     -------
@@ -71,7 +74,8 @@ def runSelection(refObjLoader, detector, wcs, filterName, donutSelectorTask):
     """
 
     bbox = detector.getBBox()
-    donutCatalog = refObjLoader.loadPixelBox(bbox, wcs, filterName).refCat
+    trimmedBBox = bbox.erodedBy(edgeMargin)
+    donutCatalog = refObjLoader.loadPixelBox(trimmedBBox, wcs, filterName).refCat
 
     if donutSelectorTask is None:
         return donutCatalog, [[]] * len(donutCatalog), [[]] * len(donutCatalog)

--- a/python/lsst/ts/wep/task/generateDonutCatalogWcsTask.py
+++ b/python/lsst/ts/wep/task/generateDonutCatalogWcsTask.py
@@ -97,6 +97,9 @@ class GenerateDonutCatalogWcsTaskConfig(
     doDonutSelection = pexConfig.Field(
         doc="Whether or not to run donut selector.", dtype=bool, default=True
     )
+    edgeMargin = pexConfig.Field(
+        doc="Size of detector edge margin in pixels", dtype=int, default=80
+    )
     # When matching photometric filters are not available in
     # the reference catalog (e.g. Gaia) use anyFilterMapsToThis
     # to get sources out of the catalog.
@@ -163,6 +166,7 @@ class GenerateDonutCatalogWcsTask(pipeBase.PipelineTask):
         detector = exposure.getDetector()
         detectorWcs = exposure.getWcs()
         anyFilterMapsToThis = self.config.anyFilterMapsToThis
+        edgeMargin = self.config.edgeMargin
         filterName = (
             exposure.filter.bandLabel
             if anyFilterMapsToThis is None
@@ -176,7 +180,12 @@ class GenerateDonutCatalogWcsTask(pipeBase.PipelineTask):
                 self.donutSelector if self.config.doDonutSelection is True else None
             )
             refSelection, blendCentersX, blendCentersY = runSelection(
-                refObjLoader, detector, detectorWcs, filterName, donutSelectorTask
+                refObjLoader,
+                detector,
+                detectorWcs,
+                filterName,
+                donutSelectorTask,
+                edgeMargin,
             )
 
         # Except RuntimeError caused when no reference catalog

--- a/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
+++ b/python/lsst/ts/wep/task/generateDonutDirectDetectTask.py
@@ -123,6 +123,9 @@ class GenerateDonutDirectDetectTaskConfig(
     doDonutSelection = pexConfig.Field(
         doc="Whether or not to run donut selector.", dtype=bool, default=True
     )
+    edgeMargin = pexConfig.Field(
+        doc="Size of detector edge margin in pixels", dtype=int, default=80
+    )
 
 
 class GenerateDonutDirectDetectTask(pipeBase.PipelineTask):
@@ -270,9 +273,15 @@ class GenerateDonutDirectDetectTask(pipeBase.PipelineTask):
             isBinary=True,
         )
 
+        # Trim the exposure by the margin
+        edgeMargin = self.config.edgeMargin
+        bbox = exposure.getBBox()
+        trimmedBBox = bbox.erodedBy(edgeMargin)
+        exposureTrim = exposure[trimmedBBox].clone()
+
         # Run the measurement task
         objData = self.measurementTask.run(
-            exposure,
+            exposureTrim,
             template,
             donutDiameter=np.ceil(instrument.donutDiameter).astype(int),
             cutoutPadding=self.config.initialCutoutPadding,

--- a/python/lsst/ts/wep/task/generateDonutFromRefitWcsTask.py
+++ b/python/lsst/ts/wep/task/generateDonutFromRefitWcsTask.py
@@ -158,6 +158,9 @@ class GenerateDonutFromRefitWcsTaskConfig(
         dtype=bool,
         default=False,
     )
+    edgeMargin = pexConfig.Field(
+        doc="Size of detector edge margin in pixels", dtype=int, default=80
+    )
 
     # Took these defaults from atmospec/centroiding which I used
     # as a template for implementing WCS fitting in a task.
@@ -407,12 +410,14 @@ class GenerateDonutFromRefitWcsTask(GenerateDonutCatalogWcsTask):
                 donutSelectorTask = (
                     self.donutSelector if self.config.doDonutSelection is True else None
                 )
+                edgeMargin = self.config.edgeMargin
                 refSelection, blendCentersX, blendCentersY = runSelection(
                     photoRefObjLoader,
                     detector,
                     exposure.wcs,
                     filterName,
                     donutSelectorTask,
+                    edgeMargin,
                 )
                 # Create list of filters to include in final catalog
                 filterList = self.config.catalogFilterList

--- a/tests/task/test_generateDonutCatalogOnlineTask.py
+++ b/tests/task/test_generateDonutCatalogOnlineTask.py
@@ -79,10 +79,12 @@ class TestGenerateDonutCatalogOnlineTask(unittest.TestCase):
     def testValidateConfigs(self):
         self.config.filterName = "r"
         self.config.doDonutSelection = False
+        self.config.edgeMargin = 100
         task = GenerateDonutCatalogOnlineTask(config=self.config)
 
         self.assertEqual(task.config.filterName, "r")
         self.assertEqual(task.config.doDonutSelection, False)
+        self.assertEqual(task.config.edgeMargin, 100)
 
     def testGetRefObjLoader(self):
         refCatList = self._getRefCat()

--- a/tests/task/test_generateDonutCatalogUtils.py
+++ b/tests/task/test_generateDonutCatalogUtils.py
@@ -116,8 +116,9 @@ class TestGenerateDonutCatalogUtils(unittest.TestCase):
         )
         # If we have a magLimit at 17 we should cut out
         # the one source at 17.5.
+        edgeMargin = 60
         donutCatBrighterThan17, blendX, blendY = runSelection(
-            refObjLoader, detector, wcs, "g", donutSelectorTask
+            refObjLoader, detector, wcs, "g", donutSelectorTask, edgeMargin
         )
         self.assertEqual(len(donutCatBrighterThan17), 3)
 
@@ -128,9 +129,24 @@ class TestGenerateDonutCatalogUtils(unittest.TestCase):
         donutSelectorConfig.unblendedSeparation = 1
         donutSelectorTask = DonutSourceSelectorTask(config=donutSelectorConfig)
         donutCatFull, blendX, blendY = runSelection(
-            refObjLoader, detector, wcs, "g", donutSelectorTask
+            refObjLoader, detector, wcs, "g", donutSelectorTask, edgeMargin
         )
         self.assertEqual(len(donutCatFull), 4)
+
+        # If we set the margin to a large value we will exclude
+        # most sources from the catalog
+        edgeMargin = 1000
+        donutCatSmall, blendX, blendY = runSelection(
+            refObjLoader, detector, wcs, "g", donutSelectorTask, edgeMargin
+        )
+        self.assertEqual(len(donutCatSmall), 1)
+
+        # This will happen even if we turn off donut selection
+        edgeMargin = 1000
+        donutCatSmall, blendX, blendY = runSelection(
+            refObjLoader, detector, wcs, "g", None, edgeMargin
+        )
+        self.assertEqual(len(donutCatSmall), 1)
 
     def testRunSelectionNoTask(self):
         refObjLoader = self._createRefObjLoader()
@@ -150,7 +166,7 @@ class TestGenerateDonutCatalogUtils(unittest.TestCase):
         # When passing None instead of a DonutSourceSelectorTask
         # we should get the full catalog without cuts.
         unchangedCat, blendX, blendY = runSelection(
-            refObjLoader, detector, wcs, "g", None
+            refObjLoader, detector, wcs, "g", None, 60
         )
         self.assertEqual(len(unchangedCat), 4)
         self.assertEqual(blendX, [[]] * 4)

--- a/tests/task/test_generateDonutCatalogWcsTask.py
+++ b/tests/task/test_generateDonutCatalogWcsTask.py
@@ -67,10 +67,12 @@ class TestGenerateDonutCatalogWcsTask(TestCase):
     def testValidateConfigs(self):
         self.config.doDonutSelection = False
         self.config.anyFilterMapsToThis = "phot_g_mean"
+        self.config.edgeMargin = 100
         self.task = GenerateDonutCatalogWcsTask(config=self.config)
 
         self.assertEqual(self.task.config.doDonutSelection, False)
         self.assertEqual(self.task.config.anyFilterMapsToThis, "phot_g_mean")
+        self.assertEqual(self.task.config.edgeMargin, 100)
 
     def testAnyFilterMapsToThis(self):
         self.config.anyFilterMapsToThis = "r"

--- a/tests/task/test_generateDonutDirectDetectTask.py
+++ b/tests/task/test_generateDonutDirectDetectTask.py
@@ -103,6 +103,7 @@ class TestGenerateDonutDirectDetectTask(lsst.utils.tests.TestCase):
     def testValidateConfigs(self):
         # Test config in task
         self.config.opticalModel = "another"
+        self.config.edgeMargin = 100
         # Test config in measurement sub task
         self.config.measurementTask.nSigmaDetection = 5.0
         # Test config in source selector sub task
@@ -110,6 +111,7 @@ class TestGenerateDonutDirectDetectTask(lsst.utils.tests.TestCase):
         self.task = GenerateDonutDirectDetectTask(config=self.config)
 
         self.assertEqual(self.task.config.opticalModel, "another")
+        self.assertEqual(self.task.config.edgeMargin, 100)
         self.assertEqual(self.task.config.measurementTask.nSigmaDetection, 5.0)
         self.assertEqual(self.task.config.donutSelector.useCustomMagLimit, True)
 

--- a/tests/task/test_generateDonutFromRefitWcsTask.py
+++ b/tests/task/test_generateDonutFromRefitWcsTask.py
@@ -144,6 +144,7 @@ class TestGenerateDonutFromRefitWcsTask(unittest.TestCase):
     def testValidateConfigs(self):
         # Test some defaults
         self.assertEqual(self.config.maxFitScatter, 1.0)
+        self.assertEqual(self.config.edgeMargin, 80)
         self.assertEqual(self.config.astromTask.referenceSelector.magLimit.maximum, 15)
         self.assertEqual(self.config.astromRefFilter, "phot_g_mean")
 
@@ -152,6 +153,7 @@ class TestGenerateDonutFromRefitWcsTask(unittest.TestCase):
         self.config.astromTask.matcher.maxOffsetPix = 2500
         self.config.astromRefFilter = "g"
         self.config.photoRefFilter = "g"
+        self.config.edgeMargin = 400
 
         # Test new settings
         task = GenerateDonutFromRefitWcsTask(config=self.config)
@@ -159,6 +161,7 @@ class TestGenerateDonutFromRefitWcsTask(unittest.TestCase):
         self.assertEqual(task.config.astromTask.matcher.maxOffsetPix, 2500)
         self.assertEqual(task.config.astromRefFilter, "g")
         self.assertEqual(task.config.photoRefFilter, "g")
+        self.assertEqual(task.config.edgeMargin, 400)
 
     def testTaskFit(self):
         preFitExp_S11, directDetectCat, dataRefs = self._getInputData()


### PR DESCRIPTION
Hitherto if `donutSelector` was off,  we would include in `donutTable` donuts that were potentially too close to the detector edge to be cutout at the `cutOutDonuts` stage. This solution avoids including these in any `donutTable`.